### PR TITLE
refactor: remove duplicate AppConfig

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text.Json;
+using leituraWPF.Utils;
 
 namespace leituraWPF
 {
@@ -27,32 +28,4 @@ namespace leituraWPF
             app.Run(new MainWindow());
         }
     }
-
-    // Program.cs  (apenas a classe AppConfig mudou)
-    public sealed class AppConfig
-    {
-        public string TenantId { get; set; } = "";
-        public string ClientId { get; set; } = "";
-        public string ClientSecret { get; set; } = "";
-        public string GraphScope { get; set; } = "https://graph.microsoft.com/.default";
-
-        public string SiteId { get; set; } = "";
-        public string ListId { get; set; } = "";
-
-        public string[] WantedPrefixes { get; set; } = Array.Empty<string>();
-
-        // >>> Novas propriedades de performance <<<
-        public int MaxParallelDownloads { get; set; } = 8;     // quantos downloads simultâneos
-        public int HttpTimeoutSeconds { get; set; } = 120;   // timeout por request
-        public bool SkipUnchanged { get; set; } = true;  // pular arquivos com mesma ETag
-        public bool ForceDriveSearch { get; set; } = true;
-
-        // Configurações de backup contínuo
-        public string BackupSiteId { get; set; } = string.Empty;
-        public string BackupDriveId { get; set; } = string.Empty; // opcional
-        public string BackupListId { get; set; } = string.Empty;  // opcional
-        public string BackupFolder { get; set; } = "LogsRenomeacao";
-        public int BackupPollSeconds { get; set; } = 30;
-    }
-
 }

--- a/leituraWPF/Services/BackupUploaderService.cs
+++ b/leituraWPF/Services/BackupUploaderService.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using leituraWPF.Utils;
 
 namespace leituraWPF.Services
 {

--- a/leituraWPF/Services/TokenService.cs
+++ b/leituraWPF/Services/TokenService.cs
@@ -2,16 +2,17 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using leituraWPF.Utils;
 
 namespace leituraWPF.Services
 {
     public sealed class TokenService
     {
-        private readonly leituraWPF.AppConfig _cfg;
+        private readonly AppConfig _cfg;
         private readonly IConfidentialClientApplication _app;
         private readonly string _cachePath;
 
-        public TokenService(leituraWPF.AppConfig cfg)
+        public TokenService(AppConfig cfg)
         {
             _cfg = cfg;
 


### PR DESCRIPTION
## Summary
- remove duplicate AppConfig class and use shared version from Utils
- fix services to reference the unified AppConfig type

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c89c49108333b47bdd831fa3a19c