### PR TITLE
Add login screen with offline employee CSV sync

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Text.Json;
+using System.Windows;
+using leituraWPF.Services;
+using leituraWPF.Views;
 
 namespace leituraWPF
 {
@@ -22,9 +25,28 @@ namespace leituraWPF
                 PropertyNameCaseInsensitive = true
             }) ?? new AppConfig();
 
+            // Tenta baixar o CSV de funcionários
+            var csvPath = Path.Combine(AppContext.BaseDirectory, "funcionarios.csv");
+            try
+            {
+                var tokenSvc = new TokenService(Config);
+                var csvSvc = new FuncionarioCsvService(Config, tokenSvc);
+                csvSvc.DownloadAsync(csvPath).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignora erros de download; será verificada a existência do arquivo abaixo
+            }
+
+            if (!File.Exists(csvPath))
+            {
+                MessageBox.Show("Não foi possível obter o arquivo de funcionários.", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             var app = new App();
             app.InitializeComponent();
-            app.Run(new MainWindow());
+            app.Run(new LoginWindow(csvPath));
         }
     }
 

--- a/leituraWPF/Services/FuncionarioCsvService.cs
+++ b/leituraWPF/Services/FuncionarioCsvService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace leituraWPF.Services
+{
+    /// <summary>
+    /// Responsável por baixar o arquivo funcionarios.csv do SharePoint.
+    /// </summary>
+    public sealed class FuncionarioCsvService
+    {
+        private readonly AppConfig _cfg;
+        private readonly TokenService _tokenService;
+
+        public FuncionarioCsvService(AppConfig cfg, TokenService tokenService)
+        {
+            _cfg = cfg;
+            _tokenService = tokenService;
+        }
+
+        /// <summary>
+        /// Baixa o arquivo funcionarios.csv para o caminho informado.
+        /// Caso o arquivo não exista no SharePoint, nada é baixado.
+        /// </summary>
+        public async Task DownloadAsync(string destinationPath, CancellationToken ct = default)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath) ?? ".");
+
+            var token = await _tokenService.GetTokenAsync().ConfigureAwait(false);
+
+            using var http = new HttpClient();
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Resolve driveId a partir da ListId configurada
+            var driveUrl = $"https://graph.microsoft.com/v1.0/sites/{_cfg.SiteId}/lists/{_cfg.ListId}/drive";
+            using var driveResp = await http.GetAsync(driveUrl, ct).ConfigureAwait(false);
+            driveResp.EnsureSuccessStatusCode();
+            var driveJson = await driveResp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var driveNode = JsonNode.Parse(driveJson)?.AsObject();
+            var driveId = driveNode?["id"]?.ToString();
+            if (string.IsNullOrWhiteSpace(driveId))
+                throw new InvalidOperationException("Não foi possível resolver o driveId para a lista configurada.");
+
+            // Busca pelo arquivo funcionarios.csv
+            var searchUrl = $"https://graph.microsoft.com/v1.0/drives/{driveId}/root/search(q='funcionarios.csv')?$top=1";
+            using var searchResp = await http.GetAsync(searchUrl, ct).ConfigureAwait(false);
+            searchResp.EnsureSuccessStatusCode();
+            var searchJson = await searchResp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var root = JsonNode.Parse(searchJson)?.AsObject();
+            var array = root?["value"] as JsonArray;
+            var item = array?.Select(v => v as JsonObject)
+                             .FirstOrDefault(o => string.Equals(o?["name"]?.ToString(), "funcionarios.csv", StringComparison.OrdinalIgnoreCase));
+            if (item == null)
+                return; // Arquivo não encontrado
+
+            var itemId = item["id"]?.ToString();
+            if (string.IsNullOrWhiteSpace(itemId))
+                return;
+
+            var downloadUrl = $"https://graph.microsoft.com/v1.0/drives/{driveId}/items/{itemId}/content";
+            using var fileResp = await http.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+            fileResp.EnsureSuccessStatusCode();
+            await using var fs = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await fileResp.Content.CopyToAsync(fs, ct).ConfigureAwait(false);
+        }
+    }
+}
+

--- a/leituraWPF/Views/LoginWindow.xaml
+++ b/leituraWPF/Views/LoginWindow.xaml
@@ -1,0 +1,17 @@
+<Window x:Class="leituraWPF.Views.LoginWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Login" Height="200" Width="350"
+        WindowStartupLocation="CenterScreen">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Matrícula" FontSize="14"/>
+        <TextBox x:Name="TxtMatricula" Grid.Row="1" Margin="0,5,0,10" Height="30"/>
+        <Button Grid.Row="2" Content="Entrar" Width="80" Height="30" HorizontalAlignment="Center"
+                Click="BtnEntrar_Click"/>
+    </Grid>
+</Window>

--- a/leituraWPF/Views/LoginWindow.xaml.cs
+++ b/leituraWPF/Views/LoginWindow.xaml.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows;
+
+namespace leituraWPF.Views
+{
+    public partial class LoginWindow : Window
+    {
+        private readonly string _csvPath;
+
+        public LoginWindow(string csvPath)
+        {
+            InitializeComponent();
+            _csvPath = csvPath;
+        }
+
+        private void BtnEntrar_Click(object sender, RoutedEventArgs e)
+        {
+            var matricula = TxtMatricula.Text.Trim();
+            if (string.IsNullOrWhiteSpace(matricula))
+            {
+                MessageBox.Show("Informe a matrícula.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (!File.Exists(_csvPath))
+            {
+                MessageBox.Show("Arquivo de funcionários não encontrado.", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            bool encontrado = File.ReadLines(_csvPath)
+                                   .Where(l => !string.IsNullOrWhiteSpace(l) && char.IsDigit(l[0]))
+                                   .Select(l => l.Split(',')[0].Trim('\"'))
+                                   .Any(code => string.Equals(code, matricula, StringComparison.OrdinalIgnoreCase));
+
+            if (encontrado)
+            {
+                var main = new MainWindow();
+                Application.Current.MainWindow = main;
+                main.Show();
+                Close();
+            }
+            else
+            {
+                MessageBox.Show("Matrícula não encontrada.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- download `funcionarios.csv` from SharePoint on startup and gate app launch if unavailable
- add login window that validates matricula against the CSV

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca4d884c833382cef4311b858b2c