### PR TITLE
Ensure app launches main window after login

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -54,9 +54,11 @@ namespace leituraWPF
 
             var app = new App();
             app.InitializeComponent();
+            app.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
             if (login.ShowDialog() == true)
             {
+                app.ShutdownMode = ShutdownMode.OnMainWindowClose;
                 app.Run(new MainWindow());
             }
         }


### PR DESCRIPTION
## Summary
- prevent application shutdown after login by setting explicit shutdown mode before showing the login window
- restore normal shutdown behavior once the main window runs

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ce92c9048333b8dec6a757b2cd7a