### PR TITLE
Exibe usuário logado na tela principal

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -34,10 +34,17 @@ namespace leituraWPF
 
         private readonly ObservableCollection<LogEntry> _logItems = new();
         private List<ClientRecord> _cacheRecords = new();
+        private readonly Funcionario? _funcionario;
 
-        public MainWindow()
+        public MainWindow(Funcionario? funcionario = null)
         {
             InitializeComponent();
+
+            _funcionario = funcionario;
+            if (_funcionario != null)
+            {
+                LblUsuario.Text = $"Usuário: {_funcionario.Nome}";
+            }
 
             _downloadsDir = Path.Combine(AppContext.BaseDirectory, "downloads");
             Directory.CreateDirectory(_downloadsDir);

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -57,7 +57,7 @@ namespace leituraWPF
 
             if (login.ShowDialog() == true)
             {
-                app.Run(new MainWindow());
+                app.Run(new MainWindow(login.FuncionarioLogado));
             }
         }
     }


### PR DESCRIPTION
## Summary
- mostra quem fez login no canto inferior
- ajusta fluxo de inicialização para repassar usuário logado

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cebc03a08333858300184df39aa8