### PR TITLE
Fix ambiguous Application and MessageBox references

### DIFF
--- a/leituraWPF/App.xaml.cs
+++ b/leituraWPF/App.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace leituraWPF
 {
-    public partial class App : Application
+    public partial class App : System.Windows.Application
     {
     }
 }

--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -141,7 +141,7 @@ namespace leituraWPF
                         CreateNoWindow = true
                     });
 
-                    Application.Current.Shutdown();
+                    System.Windows.Application.Current.Shutdown();
                 }
             }
             catch (Exception ex)

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -63,7 +63,7 @@ namespace leituraWPF
             var csvPath = Path.Combine(baseDir, "funcionarios.csv");
             if (!File.Exists(csvPath))
             {
-                MessageBox.Show("Arquivo de funcionários não disponível e não foi possível baixá-lo.",
+                System.Windows.MessageBox.Show("Arquivo de funcionários não disponível e não foi possível baixá-lo.",
                                 "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }

--- a/leituraWPF/Services/RenamerService.cs
+++ b/leituraWPF/Services/RenamerService.cs
@@ -181,7 +181,7 @@ namespace leituraWPF.Services
                 if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder).Any())
                 {
                     // Mostra alerta visual sem travar o programa
-                    MessageBox.Show(
+                    System.Windows.MessageBox.Show(
                         "A pasta de origem não contém arquivos. Selecione arquivos para continuar.",
                         "Aviso",
                         MessageBoxButton.OK,
@@ -201,7 +201,7 @@ namespace leituraWPF.Services
                 // 3) Verifica destino já existente antes de criar
                 if (Directory.Exists(clienteDir) && Directory.EnumerateFileSystemEntries(clienteDir).Any())
                 {
-                    MessageBox.Show("A pasta de destino já contém arquivos.",
+                    System.Windows.MessageBox.Show("A pasta de destino já contém arquivos.",
                                     "Destino Não Vazio",
                                     MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;

--- a/leituraWPF/Services/TrayService.cs
+++ b/leituraWPF/Services/TrayService.cs
@@ -25,7 +25,7 @@ namespace leituraWPF.Services
             var menu = new ContextMenuStrip();
             menu.Items.Add("Abrir o aplicativo", null, (s, e) => _showWindow());
             menu.Items.Add("Iniciar sincronização manual", null, (s, e) => _sync());
-            menu.Items.Add("Fechar o aplicativo", null, (s, e) => Application.Current?.Shutdown());
+            menu.Items.Add("Fechar o aplicativo", null, (s, e) => System.Windows.Application.Current?.Shutdown());
             _notifyIcon.ContextMenuStrip = menu;
             _notifyIcon.DoubleClick += (s, e) => _showWindow();
         }

--- a/leituraWPF/Views/FallbackWindow.xaml.cs
+++ b/leituraWPF/Views/FallbackWindow.xaml.cs
@@ -255,12 +255,12 @@ namespace leituraWPF
             // validações mínimas
             if (string.IsNullOrWhiteSpace(TxtIdSigfi.Text) || TxtIdSigfi.Text.Length <= _ufPrefixo.Length)
             {
-                MessageBox.Show(this, "Complete o ID SIGFI.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
+                System.Windows.MessageBox.Show(this, "Complete o ID SIGFI.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
             if (_allowAnyId && CmbRota.SelectedItem == null)
             {
-                MessageBox.Show(this, "Selecione a rota.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
+                System.Windows.MessageBox.Show(this, "Selecione a rota.", "Atenção", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -291,7 +291,7 @@ namespace leituraWPF
 
                 RenamedSuccessfully = true;
 
-                MessageBox.Show(this,
+                System.Windows.MessageBox.Show(this,
                     $"Arquivos processados com sucesso!\nDestino:\n{_renamer.LastDestination}",
                     "Sucesso", MessageBoxButton.OK, MessageBoxImage.Information);
 
@@ -300,14 +300,14 @@ namespace leituraWPF
             }
             catch (OperationCanceledException)
             {
-                MessageBox.Show(this, "Operação cancelada.", "Cancelado",
+                System.Windows.MessageBox.Show(this, "Operação cancelada.", "Cancelado",
                                 MessageBoxButton.OK, MessageBoxImage.Information);
                 BtnOk.IsEnabled = true;
                 BtnCancel.IsEnabled = true;
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, $"Falha ao processar arquivos:\n{ex.Message}",
+                System.Windows.MessageBox.Show(this, $"Falha ao processar arquivos:\n{ex.Message}",
                                 "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
                 BtnOk.IsEnabled = true;
                 BtnCancel.IsEnabled = true;

--- a/leituraWPF/Views/LoginWindow.xaml.cs
+++ b/leituraWPF/Views/LoginWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace leituraWPF
             }
             else
             {
-                MessageBox.Show("Matrícula não encontrada.", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                System.Windows.MessageBox.Show("Matrícula não encontrada.", "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
     }


### PR DESCRIPTION
## Summary
- qualify WPF `Application` usages to avoid conflicts with WinForms
- qualify `MessageBox` calls so WPF dialog is used consistently

## Testing
- `dotnet build leituraWPF.sln -c Release -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a3d533f71883339cedbf3b7880169d