### PR TITLE
Read installation file locally when numOS is zero

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -368,15 +368,12 @@ namespace leituraWPF
                     return;
                 }
 
-                // ===== FLUXO 0 → INSTALAÇÃO: ler APENAS arquivo de instalação e baixar conforme necessário =====
+                // ===== FLUXO 0 → INSTALAÇÃO: ler APENAS arquivo de instalação local (sem baixar) =====
                 if (raw == "0")
                 {
-                    SetStatus("Atualizando arquivo de instalação...");
+                    SetStatus("Lendo arquivo de instalação local...");
                     progress.Visibility = Visibility.Visible;
                     progress.IsIndeterminate = true;
-
-                    // Baixa/atualiza SOMENTE “Instalacao_{UF}”
-                    await _downloader.DownloadMatchingJsonAsync(_downloadsDir, extraQueries: new[] { $"Instalacao_{uf}" });
 
                     // Lê as ROTAS direto do(s) arquivo(s) de instalação (sem tocar no cache de manutenção)
                     var rotasInstalacao = await LoadRotasFromInstallationAsync(uf);


### PR DESCRIPTION
## Summary
- Read installation data from local files when NumOS "0" is entered, avoiding on-demand downloads

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a493f36c5c8333a254f0baf4a9e3e2