### PR TITLE
Desabilitar botões durante processamento

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -332,29 +332,46 @@ namespace leituraWPF
         /* ---- Handlers ---- */
         private void btnSelecionarOrigem_Click(object sender, RoutedEventArgs e)
         {
-            var dlg = new VistaFolderBrowserDialog
+            btnSelecionarOrigem.IsEnabled = false;
+            try
             {
-                Description = "Escolha a pasta com os arquivos crus (con/c0n, inv, bat, imagens...)",
-                UseDescriptionForTitle = true,
-                ShowNewFolderButton = false,
-                Multiselect = false
-            };
+                var dlg = new VistaFolderBrowserDialog
+                {
+                    Description = "Escolha a pasta com os arquivos crus (con/c0n, inv, bat, imagens...)",
+                    UseDescriptionForTitle = true,
+                    ShowNewFolderButton = false,
+                    Multiselect = false
+                };
 
-            if (dlg.ShowDialog(this) == true)
+                if (dlg.ShowDialog(this) == true)
+                {
+                    _sourceFolderPath = dlg.SelectedPath;
+                    txtOrigem.Text = _sourceFolderPath;
+                    SetStatus("Origem definida.");
+                }
+            }
+            finally
             {
-                _sourceFolderPath = dlg.SelectedPath;
-                txtOrigem.Text = _sourceFolderPath;
-                SetStatus("Origem definida.");
+                btnSelecionarOrigem.IsEnabled = true;
             }
         }
 
         private async void btnExecutar_Click(object sender, RoutedEventArgs e)
         {
-            await SyncAndBackupAsync();
+            btnExecutar.IsEnabled = false;
+            try
+            {
+                await SyncAndBackupAsync();
+            }
+            finally
+            {
+                btnExecutar.IsEnabled = true;
+            }
         }
 
         private async void btnProcessar_Click(object sender, RoutedEventArgs e)
         {
+            btnProcessar.IsEnabled = false;
             try
             {
                 var uf = GetSelectedUf();
@@ -445,7 +462,6 @@ namespace leituraWPF
                 // Achou o record no cache → renomeia aqui mesmo (manutenção)
                 if (!await EnsureSourceFolderHasFilesAsync()) return;
 
-                btnProcessar.IsEnabled = false;
                 SetStatus("Processando manutenção...");
                 progress.IsIndeterminate = false;
                 progress.Value = 0;
@@ -481,6 +497,7 @@ namespace leituraWPF
 
         private void btnAbrirPasta_Click(object sender, RoutedEventArgs e)
         {
+            btnAbrirPasta.IsEnabled = false;
             try
             {
                 var destino = _installRenamer.LastDestination;
@@ -493,6 +510,10 @@ namespace leituraWPF
             catch (Exception ex)
             {
                 Log($"[WARN] Não foi possível abrir a pasta destino: {ex.Message}");
+            }
+            finally
+            {
+                btnAbrirPasta.IsEnabled = true;
             }
         }
 


### PR DESCRIPTION
## Summary
- Bloqueia botões de seleção, sincronização, processamento e abertura de pasta até que suas operações terminem

## Testing
- `dotnet build leituraWPF/leituraWPF.csproj -c Release -r win-x64` *(falhou: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49440ef508333bd65919a6b66eb86