### PR TITLE
Manter app em tray quando fechado

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Reflection;
+using System.ComponentModel;
 using WpfMessageBox = System.Windows.MessageBox;
 
 namespace leituraWPF
@@ -42,6 +43,7 @@ namespace leituraWPF
         private readonly PeriodicTimer _autoSyncTimer = new(TimeSpan.FromMinutes(10));
         private readonly CancellationTokenSource _cts = new();
         private bool _suppressLogs = false;
+        private bool _allowClose = false;
 
         public MainWindow(Funcionario? funcionario = null)
         {
@@ -116,6 +118,17 @@ namespace leituraWPF
             this.Loaded += MainWindow_Loaded;
         }
 
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            if (!_allowClose)
+            {
+                e.Cancel = true;
+                Hide();
+                return;
+            }
+            base.OnClosing(e);
+        }
+
         protected override void OnClosed(EventArgs e)
         {
             try
@@ -128,6 +141,12 @@ namespace leituraWPF
             }
             catch { /* noop */ }
             base.OnClosed(e);
+        }
+
+        public void ForceClose()
+        {
+            _allowClose = true;
+            Close();
         }
 
         public void RunManualSync()

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -86,7 +86,8 @@ namespace leituraWPF
                         if (!main.IsVisible) main.Show();
                         main.Activate();
                     }),
-                    sync: () => main.RunManualSync());
+                    sync: () => main.RunManualSync(),
+                    exit: () => app.Dispatcher.Invoke(() => main.ForceClose()));
                 app.Run(main);
             }
         }

--- a/leituraWPF/Services/TrayService.cs
+++ b/leituraWPF/Services/TrayService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows;
 using System.Windows.Forms;
 
 namespace leituraWPF.Services
@@ -9,11 +8,13 @@ namespace leituraWPF.Services
         private readonly NotifyIcon _notifyIcon;
         private readonly Action _showWindow;
         private readonly Action _sync;
+        private readonly Action _exit;
 
-        public TrayService(Action showWindow, Action sync)
+        public TrayService(Action showWindow, Action sync, Action exit)
         {
             _showWindow = showWindow;
             _sync = sync;
+            _exit = exit;
 
             _notifyIcon = new NotifyIcon
             {
@@ -25,7 +26,7 @@ namespace leituraWPF.Services
             var menu = new ContextMenuStrip();
             menu.Items.Add("Abrir o aplicativo", null, (s, e) => _showWindow());
             menu.Items.Add("Iniciar sincronização manual", null, (s, e) => _sync());
-            menu.Items.Add("Fechar o aplicativo", null, (s, e) => System.Windows.Application.Current?.Shutdown());
+            menu.Items.Add("Fechar o aplicativo", null, (s, e) => _exit());
             _notifyIcon.ContextMenuStrip = menu;
             _notifyIcon.DoubleClick += (s, e) => _showWindow();
         }


### PR DESCRIPTION
## Summary
- Mantém a janela em execução no tray ao fechar
- Permite fechar o aplicativo pelo menu do tray
- Liga a ação de fechar à janela principal

## Testing
- `dotnet build` *(falha: Microsoft.NET.Sdk.WindowsDesktop não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a49e3ec08333b3b1717d50747217