### PR TITLE
Enable installation fallback lookup by IdSigfi

### DIFF
--- a/leituraWPF/Services/InstalacaoService.cs
+++ b/leituraWPF/Services/InstalacaoService.cs
@@ -6,36 +6,32 @@ using System.Linq;
 namespace leituraWPF.Services
 {
     /// <summary>
-    /// Serviço enxuto para trabalhar com o arquivo local Instalacao_AC.json.
-    /// O download é feito externamente via GraphDownloader.
+    /// Serviço enxuto para trabalhar com os arquivos locais de instalação
+    /// (ex.: <c>Instalacao_AC.json</c>). O download é feito externamente via
+    /// <c>GraphDownloader</c>.
     /// </summary>
     public sealed class InstalacaoService
     {
-        public static string OfflinePath =>
-            Path.Combine(AppContext.BaseDirectory, "downloads", "Instalacao_AC.json");
-
-        private void GarantirArquivoLocal()
-        {
-            if (!File.Exists(OfflinePath))
-            {
-                throw new FileNotFoundException(
-                    "Instalacao_AC.json não encontrado. Sincronize primeiro (Sincronizar Tudo) ou tente novamente o fluxo de instalação.");
-            }
-        }
+        private static string BuildPath(string uf) =>
+            Path.Combine(AppContext.BaseDirectory, "downloads", $"Instalacao_{uf}.json");
 
         /// <summary>
-        /// Busca no Instalacao_AC.json por IDSERVICOSCONJ == idSigfi.
-        /// Retorna NomeCliente e Rota, se encontrado.
+        /// Busca no arquivo <c>Instalacao_{uf}.json</c> pelo
+        /// <paramref name="idSigfi"/>. Retorna Nome do Cliente e Rota, se
+        /// encontrado; caso contrário retorna <c>null</c>.
         /// </summary>
-        public (string NomeCliente, string Rota)? BuscarPorIdSigfi(string idSigfi)
+        public (string NomeCliente, string Rota)? BuscarPorIdSigfi(string uf, string idSigfi)
         {
-            if (string.IsNullOrWhiteSpace(idSigfi)) return null;
+            if (string.IsNullOrWhiteSpace(idSigfi) || string.IsNullOrWhiteSpace(uf))
+                return null;
 
-            GarantirArquivoLocal();
+            string path = BuildPath(uf);
+            if (!File.Exists(path))
+                return null;
 
             try
             {
-                var json = File.ReadAllText(OfflinePath);
+                var json = File.ReadAllText(path);
                 var root = JObject.Parse(json);
                 var arr = root["instalacoes"] as JArray;
                 if (arr == null) return null;

--- a/leituraWPF/Views/FallbackWindow.xaml.cs
+++ b/leituraWPF/Views/FallbackWindow.xaml.cs
@@ -32,6 +32,9 @@ namespace leituraWPF
         // Conjunto de registros carregados em memória (para tentar resolver cliente/rota)
         private readonly IList<ClientRecord> _records;
 
+        // Busca auxiliar no arquivo de instalação
+        private readonly InstalacaoService _instalacaoService = new InstalacaoService();
+
         // Modo manual (permite ID livre e escolha manual da rota)
         private readonly bool _allowAnyId;
 
@@ -101,14 +104,26 @@ namespace leituraWPF
                     _records.FirstOrDefault(r =>
                         r.IdSigfi.Equals(idSigfi, StringComparison.OrdinalIgnoreCase)));
 
+                (string NomeCliente, string Rota)? encontrado = null;
+
+                if (record != null)
+                {
+                    encontrado = (record.NomeCliente, record.Rota);
+                }
+                else
+                {
+                    encontrado = await Task.Run(() =>
+                        _instalacaoService.BuscarPorIdSigfi(_ufPrefixo, idSigfi));
+                }
+
                 Dispatcher.Invoke(() =>
                 {
-                    if (record != null)
+                    if (encontrado != null)
                     {
-                        ClienteEncontrado = record.NomeCliente;
+                        ClienteEncontrado = encontrado.Value.NomeCliente;
                         LblCliente.Content = $"Cliente: {ClienteEncontrado}";
 
-                        var rotaEncontrada = record.Rota;
+                        var rotaEncontrada = encontrado.Value.Rota;
                         Rota = rotaEncontrada;
 
                         // Seleciona rota na combo (ou adiciona se não existir)


### PR DESCRIPTION
## Summary
- add InstalacaoService that resolves JSON file by UF and fetches client data by IdSigfi
- use InstalacaoService in FallbackWindow to populate client name and route when record list search fails

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5463c8083338dc8eb221a3b6b3f