### PR TITLE
Use custom tray icon when available

### DIFF
--- a/leituraWPF/Services/TrayService.cs
+++ b/leituraWPF/Services/TrayService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace leituraWPF.Services
@@ -16,9 +17,14 @@ namespace leituraWPF.Services
             _sync = sync;
             _exit = exit;
 
+            var iconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ico-app.ico");
+            var icon = File.Exists(iconPath)
+                ? new System.Drawing.Icon(iconPath)
+                : System.Drawing.SystemIcons.Application;
+
             _notifyIcon = new NotifyIcon
             {
-                Icon = System.Drawing.SystemIcons.Application,
+                Icon = icon,
                 Visible = true,
                 Text = "leituraWPF"
             };


### PR DESCRIPTION
## Summary
- load `ico-app.ico` as the tray icon when present

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ac01b7b0833382c7c2d50f0a4586