### PR TITLE
Define pasta padrão de origem para SALVAR AQUI

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -60,6 +60,12 @@ namespace leituraWPF
             _downloadsDir = Path.Combine(AppContext.BaseDirectory, "downloads");
             Directory.CreateDirectory(_downloadsDir);
 
+            // Define o caminho padrão da pasta de origem na área de trabalho
+            var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+            _sourceFolderPath = Path.Combine(desktop, "SALVAR AQUI");
+            Directory.CreateDirectory(_sourceFolderPath);
+            txtOrigem.Text = _sourceFolderPath;
+
             GridLog.ItemsSource = _logItems;
 
             _tokenService = new TokenService(Program.Config);
@@ -370,7 +376,8 @@ namespace leituraWPF
                     Description = "Escolha a pasta com os arquivos crus (con/c0n, inv, bat, imagens...)",
                     UseDescriptionForTitle = true,
                     ShowNewFolderButton = false,
-                    Multiselect = false
+                    Multiselect = false,
+                    SelectedPath = _sourceFolderPath
                 };
 
                 if (dlg.ShowDialog(this) == true)
@@ -555,7 +562,8 @@ namespace leituraWPF
                         Description = "Escolha a pasta com os arquivos crus (con/c0n, inv, bat, imagens...)",
                         UseDescriptionForTitle = true,
                         ShowNewFolderButton = false,
-                        Multiselect = false
+                        Multiselect = false,
+                        SelectedPath = _sourceFolderPath
                     };
                     if (dlg.ShowDialog(this) == true)
                     {


### PR DESCRIPTION
## Summary
- Define pasta padrão de origem apontando para Desktop/SALVAR AQUI
- Preenche caixa de origem e inicia seleção de pastas a partir desse caminho por padrão

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b05b61948333b86b090a286f9539