### PR TITLE
Corrige renomeação no fallback de instalação

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -425,15 +425,15 @@ namespace leituraWPF
                     // Lê as ROTAS direto do(s) arquivo(s) de instalação (sem tocar no cache de manutenção)
                     var rotasInstalacao = await LoadRotasFromInstallationAsync(uf);
 
-                    // Abre o fallback permitindo ID livre; usa o RENAMER padrão para manter compatibilidade de tipos
-                    // (Se no futuro você ajustar o FallbackWindow para aceitar um IRenamer, troque para _installRenamer)
+                    // Abre o fallback permitindo ID livre usando o renomeador de instalação
                     var fb = new FallbackWindow($"{uf}0",
                                                 rotasInstalacao,
                                                 uf,
                                                 new List<ClientRecord>(), // não usamos cache de manutenção aqui
-                                                _renamer,                  // mantém compatibilidade com assinatura atual
+                                                _renamer,
                                                 _sourceFolderPath,
-                                                allowAnyId: true)
+                                                allowAnyId: true,
+                                                installRenamer: _installRenamer)
                     {
                         Owner = this
                     };


### PR DESCRIPTION
## Resumo
- Permite que o fallback de instalação use o `InstallationRenamerService`
- Ajusta chamada em `MainWindow` para passar renomeador de instalação

## Testes
- `dotnet build` *(falhou: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b14ed00483339f1df5082d2105b6