### PR TITLE
Include employee info in rename log

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -56,6 +56,7 @@ namespace leituraWPF
             {
                 LblUsuario.Text = $"Usuário: {_funcionario.Nome}";
             }
+            _renamer.FuncionarioLogado = _funcionario;
 
             _downloadsDir = Path.Combine(AppContext.BaseDirectory, "downloads");
             Directory.CreateDirectory(_downloadsDir);

--- a/leituraWPF/Services/RenamerService.cs
+++ b/leituraWPF/Services/RenamerService.cs
@@ -41,6 +41,8 @@ namespace leituraWPF.Services
 
         public string LastDestination { get; private set; } = string.Empty;
 
+        public Funcionario? FuncionarioLogado { get; set; }
+
         public event Action<string>? FileReadyForBackup;
 
         #region Helpers
@@ -207,7 +209,17 @@ namespace leituraWPF.Services
                 {
                     $"Data: {now:dd/MM/yyyy}",
                     $"Hora: {now:HH:mm:ss}",
-                    $"Usuário: {Environment.UserName}",
+                    $"Usuário: {Environment.UserName}"
+                };
+
+                if (FuncionarioLogado is { } func)
+                {
+                    logLines.Add($"Funcionário: {func.Nome}");
+                    logLines.Add($"Matrícula: {func.Matricula}");
+                }
+
+                logLines.AddRange(new[]
+                {
                     $"Pasta de origem: {sourceFolder}",
                     $"NOMECLIENTE: {record.NomeCliente}",
                     $"TIPO: {record.Tipo}",
@@ -215,7 +227,8 @@ namespace leituraWPF.Services
                     $"EMPRESA: {record.Empresa}",
                     $"ROTA: {record.Rota}",
                     string.Empty,
-                    "Arquivos:" }; 
+                    "Arquivos:"
+                });
 
                 // 3) Verifica destino já existente antes de criar
                 if (Directory.Exists(clienteDir) && Directory.EnumerateFileSystemEntries(clienteDir).Any())


### PR DESCRIPTION
## Summary
- log employee name and ID when renaming files
- store logged employee in renamer service

## Testing
- `dotnet build leituraWPF.sln` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2df62488333a74c358817e9cf58