### PR TITLE
Use visual warnings instead of FileNotFoundException

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -50,13 +50,21 @@ namespace leituraWPF
             // Carrega configuração
             var path = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
             if (!File.Exists(path))
-                throw new FileNotFoundException("Arquivo appsettings.json não encontrado.", path);
-
-            var json = File.ReadAllText(path);
-            Config = System.Text.Json.JsonSerializer.Deserialize<AppConfig>(json, new JsonSerializerOptions
             {
-                PropertyNameCaseInsensitive = true
-            }) ?? new AppConfig();
+                MessageBox.Show(
+                    "Arquivo appsettings.json não encontrado. Usando configurações padrão.",
+                    "Aviso",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+            else
+            {
+                var json = File.ReadAllText(path);
+                Config = JsonSerializer.Deserialize<AppConfig>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                }) ?? new AppConfig();
+            }
 
             var baseDir = AppContext.BaseDirectory;
             var tokenService = new TokenService(Config);

--- a/leituraWPF/Services/InstallationRenamerService.cs
+++ b/leituraWPF/Services/InstallationRenamerService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace leituraWPF.Services
 {
@@ -105,11 +106,27 @@ namespace leituraWPF.Services
 
                 if (isSigfi160)
                 {
-                    if (controllers.Count != 2) throw new FileNotFoundException("[INSTALAÇÃO SIGFI160] Requer 2 controladores.");
+                    if (controllers.Count != 2)
+                    {
+                        MessageBox.Show(
+                            "[INSTALAÇÃO SIGFI160] Requer 2 controladores.",
+                            "Aviso",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                        return;
+                    }
                 }
                 else
                 {
-                    if (controllers.Count < 1) throw new FileNotFoundException("[INSTALAÇÃO] Requer pelo menos 1 controlador.");
+                    if (controllers.Count < 1)
+                    {
+                        MessageBox.Show(
+                            "[INSTALAÇÃO] Requer pelo menos 1 controlador.",
+                            "Aviso",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                        return;
+                    }
                 }
 
                 string nomeBase = Sanitize(string.Join("_", new[] { (uf ?? "").ToUpperInvariant(), nomeCliente ?? "", idSigfi ?? "", "INSTALACAO" }));

--- a/leituraWPF/Services/RenamerService.cs
+++ b/leituraWPF/Services/RenamerService.cs
@@ -255,19 +255,40 @@ namespace leituraWPF.Services
                 {
                     reqCtrl = 1;
                     if (controllers.Count != 1)
-                        throw new FileNotFoundException("[INTELBRAS] Requerido: 1 controlador.");
+                    {
+                        MessageBox.Show(
+                            "[INTELBRAS] Requerido: 1 controlador.",
+                            "Aviso",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                        return;
+                    }
                 }
                 else if (sistema == "HOPPECKE" && isSistema160)
                 {
                     reqCtrl = 2;
                     if (controllers.Count != 2)
-                        throw new FileNotFoundException("[HOPPECKE 160] Requerido: 2 controladores.");
+                    {
+                        MessageBox.Show(
+                            "[HOPPECKE 160] Requerido: 2 controladores.",
+                            "Aviso",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                        return;
+                    }
                 }
                 else
                 {
                     reqCtrl = 1; // genérico
                     if (controllers.Count < 1)
-                        throw new FileNotFoundException("Requerido: pelo menos 1 controlador.");
+                    {
+                        MessageBox.Show(
+                            "Requerido: pelo menos 1 controlador.",
+                            "Aviso",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                        return;
+                    }
                 }
 
                 // 6) Nome base


### PR DESCRIPTION
## Summary
- show message box when configuration file is missing instead of throwing
- warn about missing controller files in renamer services without crashing

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b735cf2c83339ec14798dad4ed87