### PR TITLE
Resolve MessageBox reference ambiguity in WPF project

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -51,7 +51,7 @@ namespace leituraWPF
             var path = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
             if (!File.Exists(path))
             {
-                MessageBox.Show(
+                System.Windows.MessageBox.Show(
                     "Arquivo appsettings.json não encontrado. Usando configurações padrão.",
                     "Aviso",
                     MessageBoxButton.OK,

--- a/leituraWPF/Services/InstallationRenamerService.cs
+++ b/leituraWPF/Services/InstallationRenamerService.cs
@@ -108,7 +108,7 @@ namespace leituraWPF.Services
                 {
                     if (controllers.Count != 2)
                     {
-                        MessageBox.Show(
+                        System.Windows.MessageBox.Show(
                             "[INSTALAÇÃO SIGFI160] Requer 2 controladores.",
                             "Aviso",
                             MessageBoxButton.OK,
@@ -120,7 +120,7 @@ namespace leituraWPF.Services
                 {
                     if (controllers.Count < 1)
                     {
-                        MessageBox.Show(
+                        System.Windows.MessageBox.Show(
                             "[INSTALAÇÃO] Requer pelo menos 1 controlador.",
                             "Aviso",
                             MessageBoxButton.OK,

--- a/leituraWPF/Services/RenamerService.cs
+++ b/leituraWPF/Services/RenamerService.cs
@@ -256,7 +256,7 @@ namespace leituraWPF.Services
                     reqCtrl = 1;
                     if (controllers.Count != 1)
                     {
-                        MessageBox.Show(
+                        System.Windows.MessageBox.Show(
                             "[INTELBRAS] Requerido: 1 controlador.",
                             "Aviso",
                             MessageBoxButton.OK,
@@ -269,7 +269,7 @@ namespace leituraWPF.Services
                     reqCtrl = 2;
                     if (controllers.Count != 2)
                     {
-                        MessageBox.Show(
+                        System.Windows.MessageBox.Show(
                             "[HOPPECKE 160] Requerido: 2 controladores.",
                             "Aviso",
                             MessageBoxButton.OK,
@@ -282,7 +282,7 @@ namespace leituraWPF.Services
                     reqCtrl = 1; // genérico
                     if (controllers.Count < 1)
                     {
-                        MessageBox.Show(
+                        System.Windows.MessageBox.Show(
                             "Requerido: pelo menos 1 controlador.",
                             "Aviso",
                             MessageBoxButton.OK,


### PR DESCRIPTION
## Summary
- ensure `System.Windows.MessageBox` is used explicitly to avoid ambiguity with Windows Forms
- adjust installation and renamer services to call WPF MessageBox

## Testing
- `dotnet build` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b8fbafb88333b1e466067224c09d