### PR TITLE
Fix fallback IDSigfi lookup in maintenance flow

### DIFF
--- a/leituraWPF/Views/FallbackWindow.xaml.cs
+++ b/leituraWPF/Views/FallbackWindow.xaml.cs
@@ -107,7 +107,8 @@ namespace leituraWPF
             {
                 var record = await Task.Run(() =>
                     _records.FirstOrDefault(r =>
-                        r.IdSigfi.Equals(idSigfi, StringComparison.OrdinalIgnoreCase)));
+                        r.IdSigfi.Equals(idSigfi, StringComparison.OrdinalIgnoreCase) ||
+                        (r.UF + r.IdSigfi).Equals(idSigfi, StringComparison.OrdinalIgnoreCase)));
 
                 (string NomeCliente, string Rota)? encontrado = null;
 
@@ -115,7 +116,7 @@ namespace leituraWPF
                 {
                     encontrado = (record.NomeCliente, record.Rota);
                 }
-                else
+                else if (_allowAnyId)
                 {
                     encontrado = await Task.Run(() =>
                         _instalacaoService.BuscarPorIdSigfi(_ufPrefixo, idSigfi));


### PR DESCRIPTION
## Summary
- ensure fallback in maintenance combines selected UF with IDSigFI when resolving client
- restrict maintenance fallback search to maintenance JSON files only

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bdcf61988333a9a0365404e591cf