### PR TITLE
Load base folder files into backup queue

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -105,6 +105,7 @@ namespace leituraWPF
                 });
             };
 
+            _backup.LoadPendingFromBaseDirs();
             _backup.Start();
 
             // inicia sincronização automática a cada 10 minutos (cancelável)


### PR DESCRIPTION
## Summary
- Queue existing files from configured base directories for backup processing
- Preload pending uploads from base folders during application startup

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d2529cf88333947c7c8f0b8b1b35