### PR TITLE
Include application version in log file

### DIFF
--- a/leituraWPF/Services/RenamerService.cs
+++ b/leituraWPF/Services/RenamerService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Reflection;
 using Microsoft.VisualBasic; // para InputBox
 using leituraWPF.Models;
 
@@ -209,7 +210,8 @@ namespace leituraWPF.Services
                 {
                     $"Data: {now:dd/MM/yyyy}",
                     $"Hora: {now:HH:mm:ss}",
-                    $"Usuário: {Environment.UserName}"
+                    $"Usuário: {Environment.UserName}",
+                    $"Versão: {Assembly.GetExecutingAssembly().GetName().Version}"
                 };
 
                 if (FuncionarioLogado is { } func)


### PR DESCRIPTION
## Summary
- Append local application version to log files generated by RenamerService

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a508483aac8333982e1390fa93de94