### PR TITLE
Ensure MainWindow shows after login

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -120,7 +120,10 @@ namespace leituraWPF
                     sync: () => main.RunManualSync(),
                     exit: () => app.Dispatcher.Invoke(() => main.ForceClose()));
 
-                app.Run(main);
+                // Exibe a janela principal antes de iniciar o loop da aplicação
+                app.MainWindow = main;
+                main.Show();
+                app.Run();
                 // Ao sair do Run, 'using' garante Dispose do tray e do poller
             }
             // Se o login for cancelado, o poller é descartado automaticamente aqui pelo 'using'


### PR DESCRIPTION
## Summary
- Explicitly show and assign MainWindow before starting the app loop so the main screen appears after a successful login

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50f8928088333be5a84fbaefbf3cf