### PR TITLE
Fix startup freeze from backup loader

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -105,7 +105,7 @@ namespace leituraWPF
                 });
             };
 
-            _backup.LoadPendingFromBaseDirs();
+            _ = _backup.LoadPendingFromBaseDirsAsync();
             _backup.Start();
 
             // inicia sincronização automática a cada 10 minutos (cancelável)


### PR DESCRIPTION
## Summary
- avoid deadlock by loading backup files asynchronously

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51c98cda08333ba64cbdc93101003