### PR TITLE
Run backup uploader during login

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace leituraWPF
         private bool _suppressLogs = false;
         private bool _allowClose = false;
 
-        public MainWindow(Funcionario? funcionario = null)
+        public MainWindow(Funcionario? funcionario = null, BackupUploaderService? backupService = null)
         {
             InitializeComponent();
 
@@ -72,7 +72,7 @@ namespace leituraWPF
             _tokenService = new TokenService(Program.Config);
             _downloader = new GraphDownloader(Program.Config, _tokenService, this, this);
             _jsonReader = new JsonReaderService(this);
-            _backup = new BackupUploaderService(Program.Config, _tokenService);
+            _backup = backupService ?? new BackupUploaderService(Program.Config, _tokenService);
 
             _renamer.FileReadyForBackup += async p => await _backup.EnqueueAsync(p);
             _installRenamer.FileReadyForBackup += async p => await _backup.EnqueueAsync(p);
@@ -105,8 +105,11 @@ namespace leituraWPF
                 });
             };
 
-            _ = _backup.LoadPendingFromBaseDirsAsync();
-            _backup.Start();
+            if (backupService == null)
+            {
+                _ = _backup.LoadPendingFromBaseDirsAsync();
+                _backup.Start();
+            }
 
             // inicia sincronização automática a cada 10 minutos (cancelável)
             _ = Task.Run(async () =>

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -66,8 +66,12 @@ namespace leituraWPF
             }
 
             var tokenService = new TokenService(Config);
+            using var backup = new BackupUploaderService(Config, tokenService);
+            backup.LoadPendingFromBaseDirs();
+            backup.Start();
+
             var funcService = new FuncionarioService(Config, tokenService);
-            var login = new LoginWindow(funcService);
+            var login = new LoginWindow(funcService, backup);
 
             // Cria a Application ANTES do ShowDialog (dispatcher ativo para o poller abrir janelas)
             var app = new App();
@@ -94,7 +98,7 @@ namespace leituraWPF
             {
                 app.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-                var main = new MainWindow(login.FuncionarioLogado);
+                var main = new MainWindow(login.FuncionarioLogado, backup);
 
                 void ShowMainWindow()
                 {

--- a/leituraWPF/Views/LoginWindow.xaml
+++ b/leituraWPF/Views/LoginWindow.xaml
@@ -299,10 +299,16 @@
                         <Border x:Name="StatusBorder"
                                 Style="{StaticResource InfoCard}"
                                 Visibility="Collapsed">
-                            <TextBlock x:Name="TxtSummary"
-                                       FontSize="12"
-                                       Foreground="{StaticResource Ink}"
-                                       TextWrapping="Wrap"/>
+                            <StackPanel>
+                                <TextBlock x:Name="TxtSummary"
+                                           FontSize="12"
+                                           Foreground="{StaticResource Ink}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock x:Name="TxtBackupStatus"
+                                           FontSize="12"
+                                           Foreground="{StaticResource Ink}"
+                                           Margin="0,4,0,0"/>
+                            </StackPanel>
                         </Border>
                     </StackPanel>
                 </ScrollViewer>

--- a/leituraWPF/Views/LoginWindow.xaml.cs
+++ b/leituraWPF/Views/LoginWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace leituraWPF
     public partial class LoginWindow : Window, INotifyPropertyChanged
     {
         private readonly FuncionarioService _funcService;
+        private readonly BackupUploaderService _backup;
         private IDictionary<string, Funcionario> _funcionarios = new Dictionary<string, Funcionario>();
         private bool _isLoading;
         private string _statusMessage = string.Empty;
@@ -52,11 +53,33 @@ namespace leituraWPF
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        public LoginWindow(FuncionarioService funcService)
+        public LoginWindow(FuncionarioService funcService, BackupUploaderService backup)
         {
             InitializeComponent();
             _funcService = funcService ?? throw new ArgumentNullException(nameof(funcService));
+            _backup = backup ?? throw new ArgumentNullException(nameof(backup));
             DataContext = this;
+
+            _backup.CountersChanged += (pend, sent) =>
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    long total = pend + sent;
+                    long percent = total > 0 ? (sent * 100 / total) : 0;
+                    if (StatusBorder != null)
+                        StatusBorder.Visibility = Visibility.Visible;
+                    if (TxtBackupStatus != null)
+                        TxtBackupStatus.Text = $"Backup: {sent}/{total} ({percent}%)";
+                });
+            };
+
+            Dispatcher.Invoke(() =>
+            {
+                long total = _backup.PendingCount + _backup.UploadedCountSession;
+                long percent = total > 0 ? (_backup.UploadedCountSession * 100 / total) : 0;
+                StatusBorder.Visibility = Visibility.Visible;
+                TxtBackupStatus.Text = $"Backup: {_backup.UploadedCountSession}/{total} ({percent}%)";
+            });
         }
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Start backup uploader service before login and share it with login and main windows
- Display backup progress on login screen using numeric count and percentage
- Allow main window to reuse existing backup uploader without restarting

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a528e4298083339066da33e4d6fe2b