### PR TITLE
Ensure desktop shortcut opens existing window

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -46,14 +46,10 @@ namespace leituraWPF
         {
             try
             {
-                // Timeout curto para não travar
+                // Sinaliza a instância existente para mostrar a janela principal
                 using var evt = EventWaitHandle.OpenExisting("leituraWPF_SHOW_EVENT");
-                var signaled = evt.WaitOne(TimeSpan.FromSeconds(1));
-                if (signaled)
-                {
-                    evt.Set();
-                    return;
-                }
+                evt.Set();
+                return;
             }
             catch (WaitHandleCannotBeOpenedException)
             {


### PR DESCRIPTION
## Summary
- Signal running instance when a second instance is started so clicking the desktop shortcut brings the app to the foreground

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a534cac88c833385b75669d7576a18