### PR TITLE
feat: confirm client data before processing

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -504,8 +504,16 @@ namespace leituraWPF
                     return;
                 }
 
-                // Achou o record no cache → renomeia aqui mesmo (manutenção)
+                // Achou o record no cache → confirmar dados e renomear
                 if (!await EnsureSourceFolderHasFilesAsync()) return;
+
+                var confirm = new ClientInfoWindow(record) { Owner = this };
+                var confirmed = confirm.ShowDialog() == true;
+                if (!confirmed)
+                {
+                    SetStatus("Cancelado.");
+                    return;
+                }
 
                 SetStatus("Processando manutenção...");
                 progress.IsIndeterminate = false;

--- a/leituraWPF/Views/ClientInfoWindow.xaml
+++ b/leituraWPF/Views/ClientInfoWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="leituraWPF.ClientInfoWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Confirmar Cliente" Width="400" Height="500"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock Text="Confirme os dados do cliente" FontSize="16" FontWeight="Bold" Margin="0,0,0,12"/>
+                <UniformGrid Columns="2" HorizontalAlignment="Left">
+                    <TextBlock Text="Nome:" FontWeight="Bold"/> <TextBlock Text="{Binding NomeCliente}"/>
+                    <TextBlock Text="Num OS:" FontWeight="Bold"/> <TextBlock Text="{Binding NumOS}"/>
+                    <TextBlock Text="Num Ocorrência:" FontWeight="Bold"/> <TextBlock Text="{Binding NumOcorrencia}"/>
+                    <TextBlock Text="Rota:" FontWeight="Bold"/> <TextBlock Text="{Binding Rota}"/>
+                    <TextBlock Text="Obra:" FontWeight="Bold"/> <TextBlock Text="{Binding Obra}"/>
+                    <TextBlock Text="ID Sigfi:" FontWeight="Bold"/> <TextBlock Text="{Binding IdSigfi}"/>
+                    <TextBlock Text="UC:" FontWeight="Bold"/> <TextBlock Text="{Binding UC}"/>
+                    <TextBlock Text="Empresa:" FontWeight="Bold"/> <TextBlock Text="{Binding Empresa}"/>
+                    <TextBlock Text="Tipo:" FontWeight="Bold"/> <TextBlock Text="{Binding Tipo}"/>
+                    <TextBlock Text="Tipo Desigfi:" FontWeight="Bold"/> <TextBlock Text="{Binding TipoDesigfi}"/>
+                    <TextBlock Text="UF:" FontWeight="Bold"/> <TextBlock Text="{Binding UF}"/>
+                    <TextBlock Text="Arquivo Base:" FontWeight="Bold"/> <TextBlock Text="{Binding NomeArquivoBase}"/>
+                </UniformGrid>
+            </StackPanel>
+        </ScrollViewer>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Confirmar" Width="100" Margin="0,0,8,0" IsDefault="True" Click="Confirm_Click"/>
+            <Button Content="Cancelar" Width="100" IsCancel="True" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/leituraWPF/Views/ClientInfoWindow.xaml.cs
+++ b/leituraWPF/Views/ClientInfoWindow.xaml.cs
@@ -1,0 +1,26 @@
+using leituraWPF.Models;
+using System.Windows;
+
+namespace leituraWPF
+{
+    public partial class ClientInfoWindow : Window
+    {
+        public ClientInfoWindow(ClientRecord record)
+        {
+            InitializeComponent();
+            DataContext = record;
+        }
+
+        private void Confirm_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ClientInfoWindow to display all client information
- require user confirmation of client details before processing

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d14f96048333a69d1f9702e4099e