### PR TITLE
Keep backup uploader running when minimized to tray

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -141,6 +141,8 @@ namespace leituraWPF
             {
                 e.Cancel = true;
                 Hide();
+                // garante que o serviço de backup continue ativo mesmo escondido
+                _backup.Start();
                 return;
             }
             base.OnClosing(e);
@@ -158,6 +160,16 @@ namespace leituraWPF
             }
             catch { /* noop */ }
             base.OnClosed(e);
+        }
+
+        protected override void OnStateChanged(EventArgs e)
+        {
+            base.OnStateChanged(e);
+            if (WindowState == WindowState.Minimized)
+            {
+                // assegura continuidade do upload em segundo plano
+                _backup.Start();
+            }
         }
 
         public void ForceClose()


### PR DESCRIPTION
## Summary
- Ensure backup service stays active when window is hidden to tray
- Restart backup uploader on minimize to maintain background uploads

## Testing
- `dotnet build` *(fails: The imported project "...Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d7ba19d48333b955f71e8b0c4870