### PR TITLE
Show backup status popup

### DIFF
--- a/leituraWPF/MainWindow.xaml
+++ b/leituraWPF/MainWindow.xaml
@@ -678,7 +678,9 @@
                     <StackPanel Orientation="Vertical" Margin="0,0,20,0" HorizontalAlignment="Right">
                         <TextBlock x:Name="TxtSyncStatus" Text="Backup sincronizado"
                                    FontWeight="SemiBold" FontSize="13" Foreground="#6c757d"
-                                   TextAlignment="Right"/>
+                                   TextAlignment="Right" Cursor="Hand"
+                                   MouseLeftButtonUp="TxtSyncStatus_MouseLeftButtonUp"/>
+        
                         <TextBlock x:Name="TxtLastUpdate" Text="Última atualização: --"
                                    FontSize="12" Foreground="#adb5bd" TextAlignment="Right"/>
                     </StackPanel>

--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -178,6 +178,16 @@ namespace leituraWPF
             Close();
         }
 
+        private void TxtSyncStatus_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            var pending = _backup.GetPendingFiles().Select(Path.GetFileName);
+            var sent = _backup.GetSentFiles().Select(Path.GetFileName);
+            var errors = _backup.GetErrorFiles().Select(Path.GetFileName);
+
+            var win = new BackupStatusWindow(pending, sent, errors) { Owner = this };
+            win.ShowDialog();
+        }
+
         public void RunManualSync()
         {
             _ = SyncAndBackupAsync();

--- a/leituraWPF/Services/BackupUploaderService.cs
+++ b/leituraWPF/Services/BackupUploaderService.cs
@@ -50,6 +50,21 @@ namespace leituraWPF.Services
         public DateTime? LastSuccessUtc { get; private set; }
         public bool IsRunning { get; private set; }
 
+        public IEnumerable<string> GetPendingFiles() =>
+            Directory.Exists(_pendingDir)
+                ? Directory.EnumerateFiles(_pendingDir, "*", SearchOption.AllDirectories)
+                : Enumerable.Empty<string>();
+
+        public IEnumerable<string> GetSentFiles() =>
+            Directory.Exists(_sentDir)
+                ? Directory.EnumerateFiles(_sentDir, "*", SearchOption.AllDirectories)
+                : Enumerable.Empty<string>();
+
+        public IEnumerable<string> GetErrorFiles() =>
+            Directory.Exists(_errorDir)
+                ? Directory.EnumerateFiles(_errorDir, "*", SearchOption.AllDirectories)
+                : Enumerable.Empty<string>();
+
         // Eventos
         public event Action<string>? StatusChanged;
         public event Action<string, string, long>? FileUploaded;

--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -1,0 +1,26 @@
+<Window x:Class="leituraWPF.BackupStatusWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Status do Backup" Height="400" Width="600"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <GroupBox Header="Pendentes" Grid.Column="0" Margin="5">
+            <ListBox x:Name="PendingList"/>
+        </GroupBox>
+
+        <GroupBox Header="Enviados" Grid.Column="1" Margin="5">
+            <ListBox x:Name="SentList"/>
+        </GroupBox>
+
+        <GroupBox Header="Erros" Grid.Column="2" Margin="5">
+            <ListBox x:Name="ErrorList"/>
+        </GroupBox>
+    </Grid>
+</Window>

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+
+namespace leituraWPF
+{
+    public partial class BackupStatusWindow : Window
+    {
+        public BackupStatusWindow(IEnumerable<string> pending, IEnumerable<string> sent, IEnumerable<string> errors)
+        {
+            InitializeComponent();
+
+            PendingList.ItemsSource = pending.Select(Path.GetFileName);
+            SentList.ItemsSource = sent.Select(Path.GetFileName);
+            ErrorList.ItemsSource = errors.Select(Path.GetFileName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make sync status text clickable and add popup window to inspect pending, sent, and error backup files
- expose file listing helpers from BackupUploaderService

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3da7b308333bbd0dec47fdc3f51