### PR TITLE
feat: add real-time backup progress

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -180,11 +180,7 @@ namespace leituraWPF
 
         private void TxtSyncStatus_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var pending = _backup.GetPendingFiles().Select(Path.GetFileName);
-            var sent = _backup.GetSentFiles().Select(Path.GetFileName);
-            var errors = _backup.GetErrorFiles().Select(Path.GetFileName);
-
-            var win = new BackupStatusWindow(pending, sent, errors) { Owner = this };
+            var win = new BackupStatusWindow(_backup) { Owner = this };
             win.ShowDialog();
         }
 

--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -5,22 +5,31 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip">
     <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <GroupBox Header="Pendentes" Grid.Column="0" Margin="5">
+        <GroupBox Header="Pendentes" Grid.Column="0" Grid.Row="0" Margin="5">
             <ListBox x:Name="PendingList"/>
         </GroupBox>
 
-        <GroupBox Header="Enviados" Grid.Column="1" Margin="5">
+        <GroupBox Header="Enviados" Grid.Column="1" Grid.Row="0" Margin="5">
             <ListBox x:Name="SentList"/>
         </GroupBox>
 
-        <GroupBox Header="Erros" Grid.Column="2" Margin="5">
+        <GroupBox Header="Erros" Grid.Column="2" Grid.Row="0" Margin="5">
             <ListBox x:Name="ErrorList"/>
         </GroupBox>
+
+        <StackPanel Grid.Row="1" Grid.ColumnSpan="3" Orientation="Vertical" Margin="5">
+            <ProgressBar x:Name="ProgressBar" Height="20" Minimum="0" Maximum="100"/>
+            <TextBlock x:Name="ProgressText" Text="0%" HorizontalAlignment="Center" Margin="0,5,0,0"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -1,19 +1,99 @@
-using System.Collections.Generic;
+using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using leituraWPF.Services;
 
 namespace leituraWPF
 {
     public partial class BackupStatusWindow : Window
     {
-        public BackupStatusWindow(IEnumerable<string> pending, IEnumerable<string> sent, IEnumerable<string> errors)
+        private readonly BackupUploaderService _backup;
+        private readonly ObservableCollection<string> _pending = new();
+        private readonly ObservableCollection<string> _sent = new();
+        private readonly ObservableCollection<string> _errors = new();
+
+        public BackupStatusWindow(BackupUploaderService backup)
         {
+            _backup = backup ?? throw new ArgumentNullException(nameof(backup));
+
             InitializeComponent();
 
-            PendingList.ItemsSource = pending.Select(Path.GetFileName);
-            SentList.ItemsSource = sent.Select(Path.GetFileName);
-            ErrorList.ItemsSource = errors.Select(Path.GetFileName);
+            PendingList.ItemsSource = _pending;
+            SentList.ItemsSource = _sent;
+            ErrorList.ItemsSource = _errors;
+
+            RefreshCollections();
+            UpdateProgress();
+
+            _backup.FileUploaded += OnFileUploaded;
+            _backup.FileUploadFailed += OnFileUploadFailed;
+            _backup.CountersChangedDetailed += OnCountersChanged;
+        }
+
+        private void OnFileUploaded(string localPath, string remotePath, long size)
+        {
+            var name = Path.GetFileName(localPath);
+            Dispatcher.Invoke(() =>
+            {
+                _pending.Remove(name);
+                if (!_sent.Contains(name))
+                    _sent.Add(name);
+                UpdateProgress();
+            });
+        }
+
+        private void OnFileUploadFailed(string localPath, string name, Exception ex)
+        {
+            var fname = Path.GetFileName(localPath);
+            Dispatcher.Invoke(() =>
+            {
+                _pending.Remove(fname);
+                if (!_errors.Contains(fname))
+                    _errors.Add(fname);
+                UpdateProgress();
+            });
+        }
+
+        private void OnCountersChanged(int pending, long uploaded, long error)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                RefreshCollections();
+                UpdateProgress();
+            });
+        }
+
+        private void RefreshCollections()
+        {
+            _pending.Clear();
+            foreach (var p in _backup.GetPendingFiles().Select(Path.GetFileName))
+                _pending.Add(p);
+
+            _sent.Clear();
+            foreach (var s in _backup.GetSentFiles().Select(Path.GetFileName))
+                _sent.Add(s);
+
+            _errors.Clear();
+            foreach (var e in _backup.GetErrorFiles().Select(Path.GetFileName))
+                _errors.Add(e);
+        }
+
+        private void UpdateProgress()
+        {
+            var total = _pending.Count + _sent.Count + _errors.Count;
+            double percent = total == 0 ? 0 : (_sent.Count + _errors.Count) * 100.0 / total;
+            ProgressBar.Value = percent;
+            ProgressText.Text = $"{percent:0}%";
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _backup.FileUploaded -= OnFileUploaded;
+            _backup.FileUploadFailed -= OnFileUploadFailed;
+            _backup.CountersChangedDetailed -= OnCountersChanged;
+            base.OnClosed(e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add progress bar and percentage to backup status window
- update status window in real time using BackupUploaderService events
- simplify sync status click handler

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e916013883338274ad04819eacf8