### PR TITLE
Fix history list bindings in backup status window

### DIFF
--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -255,7 +255,7 @@
                             <TextBlock Text="Enviados" Foreground="#666"/>
                         </StackPanel>
                     </GroupBox.Header>
-                    <DataGrid x:Name="HistorySentList" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
+                    <DataGrid x:Name="HistorySentList" ItemsSource="{Binding HistorySent}" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Data" Binding="{Binding CompletedAt, StringFormat={}{0:dd/MM/yyyy HH:mm}}" Width="150"/>
                             <DataGridTextColumn Header="Arquivo" Binding="{Binding FileName}" Width="*"/>
@@ -278,7 +278,7 @@
                             <TextBlock Text="Erros" Foreground="#666"/>
                         </StackPanel>
                     </GroupBox.Header>
-                    <DataGrid x:Name="HistoryErrorList" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
+                    <DataGrid x:Name="HistoryErrorList" ItemsSource="{Binding HistoryErrors}" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Data" Binding="{Binding CompletedAt, StringFormat={}{0:dd/MM/yyyy HH:mm}}" Width="150"/>
                             <DataGridTextColumn Header="Arquivo" Binding="{Binding FileName}" Width="*"/>

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -60,6 +60,10 @@ namespace leituraWPF
                 OnPropertyChanged();
             }
         }
+
+        public ObservableCollection<BackupItem> HistorySent => _historySent;
+
+        public ObservableCollection<BackupItem> HistoryErrors => _historyErrors;
         #endregion
 
         #region Constructor
@@ -86,8 +90,6 @@ namespace leituraWPF
             PendingList.ItemsSource = _pending;
             SentList.ItemsSource = _sent;
             ErrorList.ItemsSource = _errors;
-            HistorySentList.ItemsSource = _historySent;
-            HistoryErrorList.ItemsSource = _historyErrors;
         }
 
         private void InitializeTimer()


### PR DESCRIPTION
## Summary
- expose backup history collections as public read-only properties
- bind history DataGrids directly to these properties

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f1ec5f4c8333b493b8fc785ec929