### PR TITLE
Corrige nomenclatura de arquivos de backup

### DIFF
--- a/leituraWPF/Services/BackupUploaderService.cs
+++ b/leituraWPF/Services/BackupUploaderService.cs
@@ -223,15 +223,16 @@ namespace leituraWPF.Services
 
             try
             {
-                var name = Path.GetFileName(filePath);
+                var originalName = Path.GetFileName(filePath);
                 var folder = Path.GetFileName(Path.GetDirectoryName(filePath)) ?? string.Empty;
-                var dst = Path.Combine(_pendingDir, folder, name);
-                var sentCandidate = Path.Combine(_sentDir, folder, name);
+                var newName = BuildBackupFileName(folder, originalName);
+                var dst = Path.Combine(_pendingDir, newName);
+                var sentCandidate = Path.Combine(_sentDir, newName);
 
                 if (File.Exists(sentCandidate) || File.Exists(dst))
                     return;
 
-                Directory.CreateDirectory(Path.GetDirectoryName(dst)!);
+                Directory.CreateDirectory(_pendingDir);
 
                 // Usar async copy com buffer menor para não bloquear
                 await CopyFileAsync(filePath, dst);
@@ -242,6 +243,25 @@ namespace leituraWPF.Services
             {
                 StatusChanged?.Invoke($"[BACKUP] ERRO ao enfileirar {Path.GetFileName(filePath)}: {ex.Message}");
             }
+        }
+
+        private static string BuildBackupFileName(string folder, string fileName)
+        {
+            if (string.IsNullOrEmpty(folder) || string.IsNullOrEmpty(fileName))
+                return fileName;
+
+            var prefix = folder.Split('_').FirstOrDefault();
+            if (string.IsNullOrEmpty(prefix))
+                return fileName;
+
+            var nameNoExt = Path.GetFileNameWithoutExtension(fileName);
+            var ext = Path.GetExtension(fileName);
+            var idx = nameNoExt.LastIndexOf('_');
+            var suffix = idx >= 0 && idx < nameNoExt.Length - 1
+                ? nameNoExt[(idx + 1)..]
+                : nameNoExt;
+
+            return $"{prefix}_{suffix}{ext}";
         }
 
         private static async Task CopyFileAsync(string source, string destination)
@@ -445,11 +465,11 @@ namespace leituraWPF.Services
 
             if (!File.Exists(file)) return;
 
-            var name = Path.GetFileName(file);
-            var size = new FileInfo(file).Length;
             var rel = Path.GetRelativePath(_pendingDir, file);
-            var sub = Path.GetDirectoryName(rel)?.Replace('\\', '/') ?? string.Empty;
-            var remoteFolder = string.IsNullOrEmpty(sub) ? _cfg.BackupFolder : $"{_cfg.BackupFolder}/{sub}";
+            var folder = Path.GetDirectoryName(rel) ?? string.Empty;
+            var name = BuildBackupFileName(folder, Path.GetFileName(file));
+            var size = new FileInfo(file).Length;
+            var remoteFolder = _cfg.BackupFolder;
 
             const int maxAttempts = 2;
             Exception? lastException = null;


### PR DESCRIPTION
## Summary
- Garante que os uploads usem o número da OS com o sufixo do arquivo
- Remove influência do nome da pasta ao enfileirar e enviar backups

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fdca56408333a250f2c8b3cc38bd