### PR TITLE
Corrige exibição de nomes no status de backup

### DIFF
--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -302,9 +302,9 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <Ellipse Grid.Column="0" Width="6" Height="6" Fill="#FFB74D" 
+                                                <Ellipse Grid.Column="0" Width="6" Height="6" Fill="#FFB74D"
                                                          VerticalAlignment="Top" Margin="0,4,12,0"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding}" TextWrapping="Wrap" 
+                                                <TextBlock Grid.Column="1" Text="{Binding DisplayText}" TextWrapping="Wrap"
                                                            FontSize="12" Foreground="{StaticResource TextGray}"/>
                                             </Grid>
                                         </Border>
@@ -331,11 +331,10 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                    <TextBlock Grid.Column="0" Text="✓" Foreground="#66BB6A" 
+                                                    <TextBlock Grid.Column="0" Text="✓" Foreground="#66BB6A"
                                                            FontWeight="Bold" FontSize="14" Margin="0,0,12,0"/>
                                                     <StackPanel Grid.Column="1">
-                                                        <TextBlock Text="{Binding}" TextWrapping="Wrap" FontSize="12" 
-                                                               Foreground="{StaticResource TextGray}"/>
+                                                        <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap" FontSize="12" Foreground="{StaticResource TextGray}"/>
                                                         <TextBlock Text="Enviado com sucesso" FontSize="10"
                                                                Foreground="#66BB6A" FontStyle="Italic" Margin="0,2,0,0"/>
                                                     </StackPanel>
@@ -364,10 +363,10 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="⚠" Foreground="#EF5350" 
+                                                <TextBlock Grid.Column="0" Text="⚠" Foreground="#EF5350"
                                                            FontWeight="Bold" FontSize="14" Margin="0,0,12,0"/>
                                                 <StackPanel Grid.Column="1">
-                                                    <TextBlock Text="{Binding}" TextWrapping="Wrap" FontSize="12" 
+                                                    <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap" FontSize="12"
                                                                Foreground="{StaticResource TextGray}"/>
                                                     <TextBlock Text="Erro no processamento" FontSize="10"
                                                                Foreground="#EF5350" FontStyle="Italic" Margin="0,2,0,0"/>

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
 using leituraWPF.Services;
-using System.Text.RegularExpressions;
 using System.Windows.Data;
 
 namespace leituraWPF
@@ -336,7 +335,7 @@ namespace leituraWPF
                     var info = new FileInfo(filePath);
                     _historySent.Add(new BackupItem
                     {
-                        FileName = ExtractOsNumber(Path.GetFileName(filePath)),
+                        FileName = ExtractOsNumber(filePath),
                         CompletedAt = info.LastWriteTime,
                         FilePath = filePath
                     });
@@ -351,7 +350,7 @@ namespace leituraWPF
                     var info = new FileInfo(filePath);
                     _historyErrors.Add(new BackupItem
                     {
-                        FileName = ExtractOsNumber(Path.GetFileName(filePath)),
+                        FileName = ExtractOsNumber(filePath),
                         CompletedAt = info.LastWriteTime,
                         FilePath = filePath
                     });
@@ -478,11 +477,20 @@ namespace leituraWPF
             return item.FileName?.Contains(HistorySearchText, StringComparison.OrdinalIgnoreCase) == true;
         }
 
-        private static string ExtractOsNumber(string fileName)
+        private static string ExtractOsNumber(string filePath)
         {
-            if (string.IsNullOrWhiteSpace(fileName)) return fileName;
-            var match = Regex.Match(fileName, "\\d+");
-            return match.Success ? match.Value : fileName;
+            if (string.IsNullOrWhiteSpace(filePath)) return filePath;
+
+            var name = Path.GetFileNameWithoutExtension(filePath);
+            if (string.IsNullOrEmpty(name)) return filePath;
+
+            var parts = name.Split('_', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2)
+            {
+                return $"{parts.First()}_{parts.Last()}";
+            }
+
+            return name;
         }
 
         private async Task CleanupAsync()


### PR DESCRIPTION
## Summary
- exibe nomes limpos dos arquivos nas listas do status de backup
- utiliza prefixo e sufixo do arquivo para identificar corretamente a OS no histórico

## Testing
- `dotnet build` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a60109d9a483338002cd3a9326eda2