### PR TITLE
Fix UF selection for OS code generation

### DIFF
--- a/leituraWPF/MainWindow.xaml
+++ b/leituraWPF/MainWindow.xaml
@@ -545,8 +545,8 @@
                                 <TextBlock Text="Estado (UF)" Style="{StaticResource FieldLabel}"/>
                                 <ComboBox x:Name="cboUf" Style="{StaticResource RoundedComboBox}"
                                           Height="42" SelectedIndex="0" VerticalContentAlignment="Center">
-                                    <ComboBoxItem Content="AC - Acre"/>
-                                    <ComboBoxItem Content="MT - Mato Grosso"/>
+                                    <ComboBoxItem Content="AC - Acre" Tag="AC"/>
+                                    <ComboBoxItem Content="MT - Mato Grosso" Tag="MT"/>
                                 </ComboBox>
                             </StackPanel>
 

--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -368,9 +368,9 @@ namespace leituraWPF
 
         private string GetSelectedUf()
         {
-            var content = (cboUf?.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "AC";
-            content = content.ToUpperInvariant();
-            return (content == "AC" || content == "MT") ? content : "AC";
+            var tag = (cboUf?.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "AC";
+            tag = tag.ToUpperInvariant();
+            return (tag == "AC" || tag == "MT") ? tag : "AC";
         }
 
         private string BuildFullNumos()


### PR DESCRIPTION
## Summary
- add UF tags to ComboBox items
- correct UF code retrieval to honor selection

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bef697708333921f1427bb913d77