### PR TITLE
Restrict maintenance cache by selected state

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -389,9 +389,13 @@ namespace leituraWPF
             {
                 try
                 {
+                    var uf = GetSelectedUf();
+                    var prefix = $"Manutencao_{uf}";
+
                     var files = Directory.EnumerateFiles(_downloadsDir, "*.json")
                         .Where(f => !Path.GetFileName(f).StartsWith("Instalacao_", StringComparison.OrdinalIgnoreCase))
                         .Where(f => !Path.GetFileName(f).Equals(".index.json", StringComparison.OrdinalIgnoreCase))
+                        .Where(f => Path.GetFileName(f).StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                         .ToList();
 
                     var all = new List<ClientRecord>();


### PR DESCRIPTION
## Summary
- Load maintenance JSON files based on the selected UF so MT only reads `Manutencao_MT`

## Testing
- `dotnet build` *(fails: The imported project "...Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c10d2a988333a304052f60e94828