### PR TITLE
Padroniza NUMOS com prefixo da UF

### DIFF
--- a/leituraWPF/Services/JsonReaderService.cs
+++ b/leituraWPF/Services/JsonReaderService.cs
@@ -61,8 +61,13 @@ namespace leituraWPF.Services
 
             foreach (JObject obj in array.OfType<JObject>())
             {
-                string numos = obj.Value<string>("NUMOS") ?? string.Empty;
-                string uf = obj.Value<string>("UF") ?? (numos.Length >= 2 ? numos[..2].ToUpperInvariant() : string.Empty);
+                string numosRaw = obj.Value<string>("NUMOS") ?? string.Empty;
+                string uf = obj.Value<string>("UF") ?? (numosRaw.Length >= 2 ? numosRaw[..2].ToUpperInvariant() : string.Empty);
+
+                // Normaliza o NUMOS garantindo o prefixo da UF
+                string numos = new string(numosRaw.Where(char.IsLetterOrDigit).ToArray());
+                if (!string.IsNullOrEmpty(uf) && !numos.StartsWith(uf, StringComparison.OrdinalIgnoreCase))
+                    numos = uf + numos;
 
                 list.Add(new ClientRecord
                 {

--- a/leituraWPF/Services/LocalDataService.cs
+++ b/leituraWPF/Services/LocalDataService.cs
@@ -113,8 +113,13 @@ namespace leituraWPF.Services
 
             foreach (JObject obj in array.OfType<JObject>())
             {
-                string numos = obj.Value<string>("NUMOS") ?? string.Empty;
-                string uf = obj.Value<string>("UF") ?? (numos.Length >= 2 ? numos[..2].ToUpperInvariant() : string.Empty);
+                string numosRaw = obj.Value<string>("NUMOS") ?? string.Empty;
+                string uf = obj.Value<string>("UF") ?? (numosRaw.Length >= 2 ? numosRaw[..2].ToUpperInvariant() : string.Empty);
+
+                // Garante que o NUMOS sempre contenha o prefixo da UF.
+                string numos = new string(numosRaw.Where(char.IsLetterOrDigit).ToArray());
+                if (!string.IsNullOrEmpty(uf) && !numos.StartsWith(uf, StringComparison.OrdinalIgnoreCase))
+                    numos = uf + numos;
 
                 list.Add(new ClientRecord
                 {


### PR DESCRIPTION
## Summary
- normaliza números de OS para sempre incluir o prefixo da UF

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c90411f88333ad5cebaebad3e6e3