### PR TITLE
Preserva arquivos locais durante atualização

### DIFF
--- a/leituraWPF/Services/AtualizadorService.cs
+++ b/leituraWPF/Services/AtualizadorService.cs
@@ -26,6 +26,19 @@ namespace leituraWPF.Services
         private const int MaxRetryAttempts = 3;
         private const int TimeoutSeconds = 60;
 
+        private static readonly string[] PreserveDirs =
+        {
+            "backup-enviados",
+            "backup-erros",
+            "backup-pendentes",
+            "downloads"
+        };
+
+        private static readonly string[] PreserveFiles =
+        {
+            "syncstats.json"
+        };
+
         private static string InstallDir => AppDomain.CurrentDomain.BaseDirectory;
         public const string UpdateSuccessMarkerFile = "update_success.flag";
         public const string UpdateErrorMarkerFile = "update_error.flag";
@@ -579,7 +592,9 @@ namespace leituraWPF.Services
 
             // Cópia com robocopy
             sb.AppendLine("call :log \"[INFO] Instalando atualização\"");
-            sb.AppendLine("robocopy \"%TEMP_DIR%\" \"%INSTALL%\" /E /R:3 /W:5 >nul 2>nul");
+            var excludeDirs = string.Join(" ", PreserveDirs.Select(d => $"\\\"{d}\\\""));
+            var excludeFiles = string.Join(" ", PreserveFiles.Select(f => $"\\\"{f}\\\""));
+            sb.AppendLine($"robocopy \"%TEMP_DIR%\" \"%INSTALL%\" /E /R:3 /W:5 /XD {excludeDirs} /XF {excludeFiles} >nul 2>nul");
             sb.AppendLine("if %ERRORLEVEL% GEQ 8 call :error \"Falha na instalação dos arquivos\"");
             sb.AppendLine();
 


### PR DESCRIPTION
## Summary
- impede que syncstats.json e pastas de backup/download sejam sobrescritos na atualização

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1ed3f9483338c9e24544035a2c4