### PR TITLE
Improve update flow with versioned success feedback

### DIFF
--- a/UpdaterHost/Program.cs
+++ b/UpdaterHost/Program.cs
@@ -80,8 +80,11 @@ namespace UpdaterHost
                         }
                     }
 
-                    // Marca sucesso
-                    WriteText(cfg.SuccessFlagPath, "ok " + DateTime.Now.ToString("s"));
+                    // Marca sucesso com informações de versão, se disponíveis
+                    var flagContent = (!string.IsNullOrWhiteSpace(cfg.OldVersion) && !string.IsNullOrWhiteSpace(cfg.NewVersion))
+                        ? $"{cfg.OldVersion}|{cfg.NewVersion}"
+                        : "ok";
+                    WriteText(cfg.SuccessFlagPath, flagContent);
                     TryDeleteFile(cfg.ErrorFlagPath, log); // TryDeleteFile já faz o Exists/try-catch interno
 
                     log.Info("Atualização concluída com sucesso.");
@@ -414,6 +417,8 @@ namespace UpdaterHost
         public string LogPath { get; private set; }
         public bool CreateShortcut { get; private set; }
         public string ShortcutName { get; private set; }
+        public string OldVersion { get; private set; }
+        public string NewVersion { get; private set; }
 
         public static Args Parse(string[] a)
         {
@@ -435,14 +440,17 @@ namespace UpdaterHost
                 ErrorFlagPath = d.TryGet("--error"),
                 LogPath = d.TryGet("--log"),
                 CreateShortcut = d.TryGetBool("--shortcut"),
-                ShortcutName = d.TryGet("--shortcutName", "CompillerLog.lnk")
+                ShortcutName = d.TryGet("--shortcutName", "CompillerLog.lnk"),
+                OldVersion = d.TryGet("--oldVersion"),
+                NewVersion = d.TryGet("--newVersion")
             };
         }
 
         public override string ToString()
         {
             return $"Install='{InstallDir}', Staging='{StagingDir}', Exe='{AppExeName}', Pid={ParentPid}, " +
-                   $"Success='{SuccessFlagPath}', Error='{ErrorFlagPath}', Log='{LogPath}', Shortcut={CreateShortcut}, ShortcutName='{ShortcutName}'";
+                   $"Success='{SuccessFlagPath}', Error='{ErrorFlagPath}', Log='{LogPath}', Shortcut={CreateShortcut}, ShortcutName='{ShortcutName}', " +
+                   $"OldVersion='{OldVersion}', NewVersion='{NewVersion}'";
         }
     }
 

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -88,9 +88,22 @@ namespace leituraWPF
                 var flag = SelfUpdateService.UpdateSuccessMarkerPath;
                 if (File.Exists(flag))
                 {
+                    var info = File.ReadAllText(flag).Trim();
                     File.Delete(flag);
+
+                    string message = "Aplicativo atualizado com sucesso!";
+                    if (!string.IsNullOrWhiteSpace(info))
+                    {
+                        var parts = info.Split('|');
+                        if (parts.Length >= 2)
+                        {
+                            message += $"\nVersão anterior: {parts[0]}";
+                            message += $"\nVersão atual: {parts[1]}";
+                        }
+                    }
+
                     System.Windows.MessageBox.Show(
-                        "Aplicativo atualizado com sucesso!",
+                        message,
                         "Atualização",
                         MessageBoxButton.OK,
                         MessageBoxImage.Information);

--- a/leituraWPF/Services/SelfUpdateService.cs
+++ b/leituraWPF/Services/SelfUpdateService.cs
@@ -137,6 +137,8 @@ namespace leituraWPF.Services
                     successFlag: UpdateSuccessMarkerPath,
                     errorFlag: UpdateErrorMarkerPath,
                     logPath: UpdateLogPath,
+                    oldVersion: check.LocalVersion?.ToString() ?? string.Empty,
+                    newVersion: check.RemoteVersion?.ToString() ?? string.Empty,
                     createShortcut: true,
                     shortcutName: "CompillerLog.lnk"
                 );
@@ -351,6 +353,7 @@ namespace leituraWPF.Services
 
         private string BuildUpdaterArgs(string installDir, string stagingDir, string appExeName,
             int parentPid, string successFlag, string errorFlag, string logPath,
+            string oldVersion, string newVersion,
             bool createShortcut, string shortcutName)
         {
             var sb = new StringBuilder();
@@ -365,6 +368,8 @@ namespace leituraWPF.Services
             A("--success", successFlag);
             A("--error", errorFlag);
             A("--log", logPath);
+            A("--oldVersion", oldVersion);
+            A("--newVersion", newVersion);
             C("--shortcut", createShortcut);
             A("--shortcutName", shortcutName);
 


### PR DESCRIPTION
## Summary
- Persist old and new versions in update success flag
- Pass version info to UpdaterHost and display it on restart

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a24abc408333b5ac33bbc21579b5