### PR TITLE
fix: target windows framework for UpdaterHost

### DIFF
--- a/UpdaterHost/UpdaterHost.csproj
+++ b/UpdaterHost/UpdaterHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- target Windows-specific framework for updater host project

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a90effb48333b40669a088fc6cd0