### PR TITLE
Fix UpdaterHost Windows targeting

### DIFF
--- a/UpdaterHost/UpdaterHost.csproj
+++ b/UpdaterHost/UpdaterHost.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- target the UpdaterHost project to `net8.0-windows`
- enable cross-platform Windows targeting for WPF

## Testing
- `dotnet restore`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a90effb48333b40669a088fc6cd0