### PR TITLE
fix: specify UpdaterHost entry point

### DIFF
--- a/UpdaterHost/UpdaterHost.csproj
+++ b/UpdaterHost/UpdaterHost.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <StartupObject>UpdaterHost.Program</StartupObject>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- designate Program as startup object to avoid multiple entry points

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa865b3c8333849cd8d67255e73b