### PR TITLE
Detecta falha precoce ao iniciar UpdaterHost

### DIFF
--- a/leituraWPF/Services/SelfUpdateService.cs
+++ b/leituraWPF/Services/SelfUpdateService.cs
@@ -159,7 +159,17 @@ namespace leituraWPF.Services
                 }
 
                 var p = Process.Start(psi);
-                if (p == null) throw new InvalidOperationException("Falha ao iniciar UpdaterHost.");
+                if (p == null)
+                    throw new InvalidOperationException("Falha ao iniciar UpdaterHost.");
+
+                // Se o processo terminar imediatamente é sinal de falha (ex.: dependências ausentes)
+                await Task.Delay(1000);
+                if (p.HasExited)
+                {
+                    var code = p.ExitCode;
+                    p.Dispose();
+                    throw new InvalidOperationException($"UpdaterHost finalizado prematuramente (código {code}).");
+                }
 
                 _logger.LogInfo("UpdaterHost iniciado. Feche o app para permitir a troca segura dos arquivos.");
                 r.Success = true;


### PR DESCRIPTION
## Summary
- Verifica se o UpdaterHost encerra imediatamente e aborta a atualização quando isso ocorre

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ac220b908333b8f1ce2516bc3506