### PR TITLE
Fix updater command-line quoting for admin relaunch

### DIFF
--- a/UpdaterHost/Program.cs
+++ b/UpdaterHost/Program.cs
@@ -411,7 +411,34 @@ namespace UpdaterHost
         private static string QuoteIfNeeded(string s)
         {
             if (string.IsNullOrEmpty(s)) return "\"\"";
-            return s.IndexOf(' ') >= 0 ? ("\"" + s.Replace("\"", "\\\"") + "\"") : s;
+            bool needQuotes = s.IndexOf(' ') >= 0 || s.IndexOf('\t') >= 0 || s.IndexOf('\"') >= 0 || s.EndsWith("\\");
+            if (!needQuotes) return s;
+
+            var sb = new System.Text.StringBuilder();
+            sb.Append('"');
+            int backslashes = 0;
+            foreach (char c in s)
+            {
+                if (c == '\\')
+                {
+                    backslashes++;
+                }
+                else if (c == '"')
+                {
+                    sb.Append('\', backslashes * 2 + 1);
+                    sb.Append('"');
+                    backslashes = 0;
+                }
+                else
+                {
+                    sb.Append('\', backslashes);
+                    backslashes = 0;
+                    sb.Append(c);
+                }
+            }
+            sb.Append('\', backslashes * 2);
+            sb.Append('"');
+            return sb.ToString();
         }
 
         // ====== Criar atalho (COM interop forte; sem dynamic) ======

--- a/leituraWPF/Services/SelfUpdateService.cs
+++ b/leituraWPF/Services/SelfUpdateService.cs
@@ -385,9 +385,9 @@ namespace leituraWPF.Services
             bool createShortcut, string shortcutName)
         {
             var sb = new StringBuilder();
-            void A(string k, string v) { sb.Append(" ").Append(k).Append(" \"").Append(v).Append("\""); }
-            void B(string k, int v) { sb.Append(" ").Append(k).Append(" ").Append(v); }
-            void C(string k, bool v) { sb.Append(" ").Append(k).Append(" ").Append(v ? "true" : "false"); }
+            void A(string k, string v) { sb.Append(' ').Append(k).Append(' ').Append(EscapeArg(v)); }
+            void B(string k, int v) { sb.Append(' ').Append(k).Append(' ').Append(v); }
+            void C(string k, bool v) { sb.Append(' ').Append(k).Append(' ').Append(v ? "true" : "false"); }
 
             A("--install", installDir);
             A("--staging", stagingDir);
@@ -401,6 +401,39 @@ namespace leituraWPF.Services
             C("--shortcut", createShortcut);
             A("--shortcutName", shortcutName);
 
+            return sb.ToString();
+        }
+
+        private static string EscapeArg(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "\"\"";
+            bool needQuotes = s.IndexOf(' ') >= 0 || s.IndexOf('\t') >= 0 || s.IndexOf('\"') >= 0 || s.EndsWith("\\");
+            if (!needQuotes) return s;
+
+            var sb = new StringBuilder();
+            sb.Append('"');
+            int backslashes = 0;
+            foreach (char c in s)
+            {
+                if (c == '\\')
+                {
+                    backslashes++;
+                }
+                else if (c == '"')
+                {
+                    sb.Append('\', backslashes * 2 + 1);
+                    sb.Append('"');
+                    backslashes = 0;
+                }
+                else
+                {
+                    sb.Append('\', backslashes);
+                    backslashes = 0;
+                    sb.Append(c);
+                }
+            }
+            sb.Append('\', backslashes * 2);
+            sb.Append('"');
             return sb.ToString();
         }
 


### PR DESCRIPTION
## Summary
- Properly escape command-line arguments when relaunching updater with elevation
- Escape arguments passed from `SelfUpdateService` to prevent quoting issues with spaces or trailing slashes

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b1d0176c8333ac5a4032d60687be