### PR TITLE
Fix escape handling for updater utilities

### DIFF
--- a/UpdaterHost/Program.cs
+++ b/UpdaterHost/Program.cs
@@ -379,8 +379,17 @@ namespace UpdaterHost
 
         private static bool CanWrite(string dir)
         {
-            try { var p = Path.Combine(dir, $"w_{Guid.NewGuid():N}.tmp"); File.WriteAllText(p, "x"); File.Delete(p); return true; }
-            catch { return false; }
+            try
+            {
+                var p = Path.Combine(dir, $"w_{Guid.NewGuid():N}.tmp");
+                File.WriteAllText(p, "x");
+                File.Delete(p);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static bool IsAdministrator()
@@ -425,18 +434,18 @@ namespace UpdaterHost
                 }
                 else if (c == '"')
                 {
-                    sb.Append('\', backslashes * 2 + 1);
+                    sb.Append(new string('\\', backslashes * 2 + 1));
                     sb.Append('"');
                     backslashes = 0;
                 }
                 else
                 {
-                    sb.Append('\', backslashes);
+                    sb.Append(new string('\\', backslashes));
                     backslashes = 0;
                     sb.Append(c);
                 }
             }
-            sb.Append('\', backslashes * 2);
+            sb.Append(new string('\\', backslashes * 2));
             sb.Append('"');
             return sb.ToString();
         }

--- a/leituraWPF/Services/SelfUpdateService.cs
+++ b/leituraWPF/Services/SelfUpdateService.cs
@@ -421,18 +421,18 @@ namespace leituraWPF.Services
                 }
                 else if (c == '"')
                 {
-                    sb.Append('\', backslashes * 2 + 1);
+                    sb.Append(new string('\\', backslashes * 2 + 1));
                     sb.Append('"');
                     backslashes = 0;
                 }
                 else
                 {
-                    sb.Append('\', backslashes);
+                    sb.Append(new string('\\', backslashes));
                     backslashes = 0;
                     sb.Append(c);
                 }
             }
-            sb.Append('\', backslashes * 2);
+            sb.Append(new string('\\', backslashes * 2));
             sb.Append('"');
             return sb.ToString();
         }
@@ -461,8 +461,17 @@ namespace leituraWPF.Services
 
         private static bool HasWritePermission(string dir)
         {
-            try { var p = Path.Combine(dir, $"perm_{Guid.NewGuid():N}.tmp"); File.WriteAllText(p, "x"); File.Delete(p); return true; }
-            catch { return false; }
+            try
+            {
+                var p = Path.Combine(dir, $"perm_{Guid.NewGuid():N}.tmp");
+                File.WriteAllText(p, "x");
+                File.Delete(p);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static Version ParseVersionFromTag(string tagName)


### PR DESCRIPTION
## Summary
- repair truncated `return` statement in updater and self-update helpers
- replace `StringBuilder.Append(char, repeatCount)` uses with `new string` to avoid char literal issues

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b46830148333a3f23de1a0a946b1