### PR TITLE
Fix updater to request admin only when necessary

### DIFF
--- a/leituraWPF/Services/AtualizadorService.cs
+++ b/leituraWPF/Services/AtualizadorService.cs
@@ -624,8 +624,13 @@ namespace leituraWPF.Services
                     FileName = batchPath,
                     UseShellExecute = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    Verb = "runas" // Executa como administrador se necessário
+                    WorkingDirectory = Path.GetDirectoryName(batchPath) ?? string.Empty
                 };
+
+                if (!CanWrite(InstallDir))
+                {
+                    startInfo.Verb = "runas"; // Eleva apenas se não houver permissão de escrita
+                }
 
                 var process = Process.Start(startInfo);
                 if (process == null)
@@ -637,6 +642,20 @@ namespace leituraWPF.Services
             {
                 _logger.LogError($"Erro ao executar script de atualização: {ex.Message}", ex);
                 throw;
+            }
+        }
+
+        private static bool CanWrite(string dir)
+        {
+            try
+            {
+                var testFile = Path.Combine(dir, Path.GetRandomFileName());
+                using (File.Create(testFile, 1, FileOptions.DeleteOnClose)) { }
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid forcing admin elevation during updates
- add write-permission check and working directory for batch update execution

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9beea08508333910079c8228e7056