### PR TITLE
Handle shutdown during updater progress reporting

### DIFF
--- a/UpdaterHost/Program.cs
+++ b/UpdaterHost/Program.cs
@@ -35,7 +35,10 @@ namespace UpdaterHost
                 {
                     try
                     {
-                        _window?.Dispatcher?.Invoke(() => _window.SetStatus(msg));
+                        if (_window != null && !_window.Dispatcher.HasShutdownStarted)
+                        {
+                            _window.Dispatcher.Invoke(() => _window.SetStatus(msg));
+                        }
                     }
                     catch (OperationCanceledException)
                     {


### PR DESCRIPTION
## Summary
- Avoid sending progress updates after the WPF dispatcher begins shutting down

## Testing
- `dotnet build` *(fails: WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c6aefaf48333a2699172f596f714