### PR TITLE
Refactor self-update and host update logic

### DIFF
--- a/UpdaterHost/Program.cs
+++ b/UpdaterHost/Program.cs
@@ -4,636 +4,126 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Windows;
 
 namespace UpdaterHost
 {
     internal static class Program
     {
-        // Janela de progresso exibida em thread separada
-        private static ProgressWindow? _window;
-
-        [STAThread]
-        private static int Main(string[] args)
+        static int Main(string[] args)
         {
             var cfg = Args.Parse(args);
-            var log = new FileLogger(cfg.LogPath);
-
-            // Inicia UI em outra thread para não bloquear o processo de atualização
-            var uiThread = new Thread(() =>
-            {
-                _window = new ProgressWindow();
-
-                // Atualiza a UI sempre que houver progresso, mas ignora
-                // sinais de cancelamento caso a janela já tenha sido
-                // encerrada. O Dispatcher lança OperationCanceledException
-                // quando está em processo de shutdown e, se não tratada,
-                // derruba o processo de atualização.
-                ProgressReporter.ProgressChanged += msg =>
-                {
-                    try
-                    {
-                        if (_window != null && !_window.Dispatcher.HasShutdownStarted)
-                        {
-                            _window.Dispatcher.Invoke(() => _window.SetStatus(msg));
-                        }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // Dispatcher foi finalizado; não há mais nada a fazer.
-                    }
-                };
-
-                var app = new Application();
-                app.Run(_window);
-            });
-            uiThread.SetApartmentState(ApartmentState.STA);
-            uiThread.Start();
-
-            // Aguarda janela ser criada
-            while (_window == null || !_window.IsLoaded)
-                Thread.Sleep(50);
-
-            int result = RunUpdate(args, cfg, log);
-
-            // Encerra UI com segurança
             try
             {
-                if (_window != null && !_window.Dispatcher.HasShutdownStarted)
-                    _window.Dispatcher.Invoke(() => _window.Close());
-            }
-            catch (OperationCanceledException)
-            {
-                // Ignorado: dispatcher já foi finalizado
-            }
-
-            uiThread.Join();
-
-            return result;
-        }
-
-        private static int RunUpdate(string[] args, Args cfg, FileLogger log)
-        {
-            try
-            {
-                log.Info("=== UpdaterHost iniciado (gerenciado, sem shell) ===");
-                log.Info("Config: " + cfg);
-
-                // Elevação se necessário
-                if (!CanWrite(cfg.InstallDir))
-                {
-                    log.Warn("Sem permissão de escrita. Tentando elevar...");
-                    if (!IsAdministrator())
-                    {
-                        RelaunchAsAdmin(args);
-                        return 0;
-                    }
-                }
-
-                // Espera o app principal fechar (por PID ou nome)
                 if (cfg.ParentPid > 0)
-                {
-                    ProgressReporter.Report($"Aguardando processo PID {cfg.ParentPid} encerrar...");
-                    log.Info($"Aguardando processo PID {cfg.ParentPid} encerrar...");
-                    WaitForPidExit(cfg.ParentPid, cfg.AppExeName, log, 120);
-                }
-                else
-                {
-                    ProgressReporter.Report($"Aguardando '{cfg.AppExeName}' encerrar...");
-                    log.Info($"Aguardando '{cfg.AppExeName}' encerrar...");
-                    WaitForProcessNameExit(cfg.AppExeName, log, 120);
-                }
+                    WaitForPidExit(cfg.ParentPid, cfg.AppExeName);
 
-                // Valida staging/instalação
-                if (!Directory.Exists(cfg.StagingDir))
-                    throw new InvalidOperationException("Staging inexistente.");
-                if (!Directory.Exists(cfg.InstallDir))
-                    throw new InvalidOperationException("Diretório de instalação inexistente.");
+                ApplyUpdate(cfg);
 
-                // Prepara backup
-                ProgressReporter.Report("Criando backup...");
-                var backupDir = Path.Combine(Path.GetTempPath(), $"backup_{Guid.NewGuid():N}");
-                log.Info($"Criando backup: {backupDir}");
-                Directory.CreateDirectory(backupDir);
-                CopyDirectory(cfg.InstallDir, backupDir, log, excludeNames: new[] { "update_success.flag", "update_error.flag", "update.log" });
+                Relaunch(cfg);
 
-                try
-                {
-                    // Aplica a atualização
-                    ProgressReporter.Report("Aplicando atualização...");
-                    log.Info("Aplicando atualização (cópia recursiva com overwrite)...");
-                    ApplyUpdate(cfg, log);
+                if (!string.IsNullOrEmpty(cfg.SuccessFlag))
+                    File.WriteAllText(cfg.SuccessFlag, $"{cfg.OldVersion}|{cfg.NewVersion}");
 
-                    // Validação pós-instalação
-                    var exePath = Path.Combine(cfg.InstallDir, cfg.AppExeName);
-                    if (!File.Exists(exePath))
-                        throw new InvalidOperationException($"Executável principal não encontrado após atualização: {exePath}");
-
-                    // Cria atalho se indicado
-                    if (cfg.CreateShortcut)
-                    {
-                        try
-                        {
-                            ProgressReporter.Report("Criando atalho...");
-                            CreateShortcutOnDesktop(cfg, exePath, log);
-                        }
-                        catch (Exception ex)
-                        {
-                            log.Warn("Falha ao criar atalho: " + ex.Message);
-                        }
-                    }
-
-                    // Marca sucesso
-                    var flagContent = (!string.IsNullOrWhiteSpace(cfg.OldVersion) && !string.IsNullOrWhiteSpace(cfg.NewVersion))
-                        ? $"{cfg.OldVersion}|{cfg.NewVersion}"
-                        : "ok";
-                    WriteText(cfg.SuccessFlagPath, flagContent);
-                    TryDeleteFile(cfg.ErrorFlagPath, log);
-
-                    log.Info("Atualização concluída com sucesso.");
-                    TryDeleteDirectory(backupDir, log);
-                }
-                catch (Exception exApply)
-                {
-                    log.Error("Erro ao aplicar atualização: " + exApply);
-
-                    // Marca erro
-                    WriteText(cfg.ErrorFlagPath, exApply.Message);
-
-                    // Rollback
-                    try
-                    {
-                        log.Warn("Iniciando ROLLBACK...");
-                        RollbackFromBackup(cfg.InstallDir, backupDir, log);
-                        log.Warn("Rollback concluído.");
-                    }
-                    catch (Exception rbEx)
-                    {
-                        log.Error("Rollback falhou: " + rbEx);
-                    }
-                }
-                finally
-                {
-                    // Limpeza do staging
-                    TryDeleteDirectory(cfg.StagingDir, log);
-                }
-
-                // Relança app
-                ProgressReporter.Report("Relançando aplicação...");
-                var relaunch = Path.Combine(cfg.InstallDir, cfg.AppExeName);
-                if (File.Exists(relaunch))
-                {
-                    log.Info("Relançando aplicação...");
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = relaunch,
-                        UseShellExecute = false,
-                        WorkingDirectory = cfg.InstallDir
-                    };
-                    Process.Start(psi);
-                }
-                else
-                {
-                    log.Warn("Executável não encontrado para relançar.");
-                }
-
-                ProgressReporter.Report("Finalizado.");
-                log.Info("UpdaterHost finalizado.");
                 return 0;
             }
             catch (Exception ex)
             {
-                try { WriteText(cfg.ErrorFlagPath, ex.Message); } catch { }
-                try
-                {
-                    var logFallback = new FileLogger(cfg.LogPath);
-                    logFallback.Error("Falha fatal no UpdaterHost: " + ex);
-                }
-                catch { }
+                if (!string.IsNullOrEmpty(cfg.ErrorFlag))
+                    File.WriteAllText(cfg.ErrorFlag, ex.Message);
                 return 1;
             }
         }
 
-        // ====== Aplicação da atualização ======
-        private static void ApplyUpdate(Args cfg, FileLogger log)
+        private static void ApplyUpdate(Args cfg)
         {
-            var installFiles = ListRelativeFiles(cfg.InstallDir);
-            var stagingFiles = ListRelativeFiles(cfg.StagingDir);
+            if (!Directory.Exists(cfg.StagingDir))
+                throw new InvalidOperationException("Staging não encontrado.");
+            if (!Directory.Exists(cfg.InstallDir))
+                Directory.CreateDirectory(cfg.InstallDir);
 
-            // Remove lixo antigo (exceto UpdaterHost.exe)
-            var toDelete = installFiles.Except(stagingFiles, StringComparer.OrdinalIgnoreCase)
-                .Where(rel => !string.Equals(Path.GetFileName(rel), "UpdaterHost.exe", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            foreach (var rel in toDelete)
+            foreach (var dir in Directory.GetDirectories(cfg.StagingDir, "*", SearchOption.AllDirectories))
             {
-                var path = Path.Combine(cfg.InstallDir, rel);
-                TryDeleteFile(path, log);
+                var rel = dir.Substring(cfg.StagingDir.Length).TrimStart(Path.DirectorySeparatorChar);
+                Directory.CreateDirectory(Path.Combine(cfg.InstallDir, rel));
             }
 
-            // Copia/atualiza
-            foreach (var rel in stagingFiles)
+            foreach (var file in Directory.GetFiles(cfg.StagingDir, "*", SearchOption.AllDirectories))
             {
-                if (string.Equals(Path.GetFileName(rel), "UpdaterHost.exe", StringComparison.OrdinalIgnoreCase))
+                var name = Path.GetFileName(file);
+                if (string.Equals(name, "UpdaterHost.exe", StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                var src = Path.Combine(cfg.StagingDir, rel);
-                var dst = Path.Combine(cfg.InstallDir, rel);
-
-                Directory.CreateDirectory(Path.GetDirectoryName(dst));
-                CopyFile(src, dst, overwrite: true, log);
+                var rel = file.Substring(cfg.StagingDir.Length).TrimStart(Path.DirectorySeparatorChar);
+                var dest = Path.Combine(cfg.InstallDir, rel);
+                Directory.CreateDirectory(Path.GetDirectoryName(dest));
+                File.Copy(file, dest, true);
             }
+
+            Directory.Delete(cfg.StagingDir, true);
         }
 
-        private static List<string> ListRelativeFiles(string root)
+        private static void Relaunch(Args cfg)
         {
-            return Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
-                .Select(p => p.Substring(root.TrimEnd(Path.DirectorySeparatorChar).Length)
-                               .TrimStart(Path.DirectorySeparatorChar))
-                .ToList();
-        }
-
-        private static void CopyDirectory(string sourceDir, string destDir, FileLogger log, IEnumerable<string> excludeNames = null)
-        {
-            excludeNames = excludeNames ?? Array.Empty<string>();
-            Directory.CreateDirectory(destDir);
-
-            foreach (var dir in Directory.GetDirectories(sourceDir, "*", SearchOption.AllDirectories))
+            var exe = Path.Combine(cfg.InstallDir, cfg.AppExeName);
+            if (File.Exists(exe))
             {
-                var rel = dir.Substring(sourceDir.TrimEnd(Path.DirectorySeparatorChar).Length)
-                             .TrimStart(Path.DirectorySeparatorChar);
-                Directory.CreateDirectory(Path.Combine(destDir, rel));
-            }
-
-            foreach (var file in Directory.GetFiles(sourceDir, "*", SearchOption.AllDirectories))
-            {
-                var name = Path.GetFileName(file);
-                if (excludeNames.Contains(name, StringComparer.OrdinalIgnoreCase)) continue;
-
-                var rel = file.Substring(sourceDir.TrimEnd(Path.DirectorySeparatorChar).Length)
-                              .TrimStart(Path.DirectorySeparatorChar);
-                var dst = Path.Combine(destDir, rel);
-                Directory.CreateDirectory(Path.GetDirectoryName(dst));
-                CopyFile(file, dst, overwrite: true, log);
-            }
-        }
-
-        private static void RollbackFromBackup(string installDir, string backupDir, FileLogger log)
-        {
-            if (!Directory.Exists(backupDir))
-                throw new InvalidOperationException("Backup ausente para rollback.");
-
-            foreach (var file in Directory.GetFiles(installDir, "*", SearchOption.AllDirectories))
-            {
-                var name = Path.GetFileName(file);
-                if (string.Equals(name, "UpdaterHost.exe", StringComparison.OrdinalIgnoreCase)) continue;
-                TryDeleteFile(file, log);
-            }
-            foreach (var dir in Directory.GetDirectories(installDir, "*", SearchOption.AllDirectories).OrderByDescending(d => d.Length))
-            {
-                TryDeleteDirectory(dir, log);
-            }
-
-            CopyDirectory(backupDir, installDir, log);
-        }
-
-        // ====== IO helpers ======
-        private static void CopyFile(string src, string dst, bool overwrite, FileLogger log)
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                try
+                Process.Start(new ProcessStartInfo
                 {
-                    if (File.Exists(dst))
-                    {
-                        var attr = File.GetAttributes(dst);
-                        if ((attr & FileAttributes.ReadOnly) != 0)
-                            File.SetAttributes(dst, attr & ~FileAttributes.ReadOnly);
-                    }
-                    File.Copy(src, dst, overwrite);
-                    return;
-                }
-                catch (IOException)
-                {
-                    Thread.Sleep(200);
-                }
-            }
-            using (var fsIn = new FileStream(src, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(dst));
-                using (var fsOut = new FileStream(dst, FileMode.Create, FileAccess.Write, FileShare.None))
-                {
-                    fsIn.CopyTo(fsOut, 1024 * 1024);
-                }
+                    FileName = exe,
+                    WorkingDirectory = cfg.InstallDir,
+                    UseShellExecute = false
+                });
             }
         }
 
-        private static void TryDeleteFile(string path, FileLogger log = null)
-        {
-            try
-            {
-                if (File.Exists(path))
-                {
-                    var a = File.GetAttributes(path);
-                    if ((a & FileAttributes.ReadOnly) != 0)
-                        File.SetAttributes(path, a & ~FileAttributes.ReadOnly);
-                    File.Delete(path);
-                }
-            }
-            catch (Exception ex) { log?.Warn($"Não foi possível excluir '{path}': {ex.Message}"); }
-        }
-
-        private static void TryDeleteDirectory(string path, FileLogger log = null)
-        {
-            try
-            {
-                if (Directory.Exists(path))
-                    Directory.Delete(path, true);
-            }
-            catch (Exception ex) { log?.Warn($"Não foi possível remover '{path}': {ex.Message}"); }
-        }
-
-        private static void WriteText(string path, string content)
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(path));
-            File.WriteAllText(path, content);
-        }
-
-        // ====== Esperas/Permissões ======
-        private static void WaitForPidExit(int pid, string exeName, FileLogger log, int timeoutSeconds)
-        {
-            var sw = Stopwatch.StartNew();
-            var exeOnly = Path.GetFileName(exeName);
-            while (sw.Elapsed.TotalSeconds < timeoutSeconds)
-            {
-                try
-                {
-                    var p = Process.GetProcessById(pid);
-                    try
-                    {
-                        var runningName = Path.GetFileName(p.MainModule.FileName);
-                        if (!string.Equals(runningName, exeOnly, StringComparison.OrdinalIgnoreCase))
-                            break;
-                    }
-                    catch { /* acesso negado em alguns casos; só espera */ }
-                }
-                catch
-                {
-                    // processo já terminou
-                    break;
-                }
-
-                Thread.Sleep(300);
-
-                if (!Process.GetProcessesByName(Path.GetFileNameWithoutExtension(exeOnly)).Any())
-                    break;
-            }
-        }
-
-        private static void WaitForProcessNameExit(string exeName, FileLogger log, int timeoutSeconds)
+        private static void WaitForPidExit(int pid, string exeName)
         {
             var name = Path.GetFileNameWithoutExtension(exeName);
-            var sw = Stopwatch.StartNew();
-            while (sw.Elapsed.TotalSeconds < timeoutSeconds)
-            {
-                if (!Process.GetProcessesByName(name).Any())
-                    return;
-                Thread.Sleep(300);
-            }
-            log.Warn("Timeout aguardando processo por nome encerrar.");
-        }
-
-        private static bool CanWrite(string dir)
-        {
             try
             {
-                var p = Path.Combine(dir, $"w_{Guid.NewGuid():N}.tmp");
-                File.WriteAllText(p, "x");
-                File.Delete(p);
-                return true;
+                while (Process.GetProcessesByName(name).Any(p => p.Id == pid))
+                    System.Threading.Thread.Sleep(300);
             }
-            catch
-            {
-                return false;
-            }
-        }
-
-        private static bool IsAdministrator()
-        {
-            try
-            {
-                var wi = System.Security.Principal.WindowsIdentity.GetCurrent();
-                var wp = new System.Security.Principal.WindowsPrincipal(wi);
-                return wp.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
-            }
-            catch { return false; }
-        }
-
-        private static void RelaunchAsAdmin(string[] args)
-        {
-            var exe = Process.GetCurrentProcess().MainModule.FileName;
-            var psi = new ProcessStartInfo
-            {
-                FileName = exe,
-                Arguments = string.Join(" ", args.Select(QuoteIfNeeded)),
-                UseShellExecute = true,
-                Verb = "runas",
-                WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory
-            };
-            Process.Start(psi);
-        }
-
-        private static string QuoteIfNeeded(string s)
-        {
-            if (string.IsNullOrEmpty(s)) return "\"\"";
-            bool needQuotes = s.IndexOf(' ') >= 0 || s.IndexOf('\t') >= 0 || s.IndexOf('\"') >= 0 || s.EndsWith("\\");
-            if (!needQuotes) return s;
-
-            var sb = new System.Text.StringBuilder();
-            sb.Append('"');
-            int backslashes = 0;
-            foreach (char c in s)
-            {
-                if (c == '\\')
-                {
-                    backslashes++;
-                }
-                else if (c == '"')
-                {
-                    sb.Append(new string('\\', backslashes * 2 + 1));
-                    sb.Append('"');
-                    backslashes = 0;
-                }
-                else
-                {
-                    sb.Append(new string('\\', backslashes));
-                    backslashes = 0;
-                    sb.Append(c);
-                }
-            }
-            sb.Append(new string('\\', backslashes * 2));
-            sb.Append('"');
-            return sb.ToString();
-        }
-
-        // ====== Criar atalho (COM interop forte; sem dynamic) ======
-        private static void CreateShortcutOnDesktop(Args cfg, string exePath, FileLogger log)
-        {
-            try
-            {
-                string desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-                string lnk = Path.Combine(desktop, cfg.ShortcutName);
-
-                var shellLink = (IShellLinkW)new ShellLink();
-                shellLink.SetPath(exePath);
-                shellLink.SetWorkingDirectory(cfg.InstallDir);
-                shellLink.SetIconLocation(exePath, 0);
-
-                var pf = (IPersistFile)shellLink;
-                pf.Save(lnk, true);
-
-                log.Info($"Atalho criado: {lnk}");
-            }
-            catch (Exception ex)
-            {
-                log.Warn("Falha ao criar atalho (IShellLinkW): " + ex.Message);
-            }
+            catch { }
         }
     }
 
-    internal static class ProgressReporter
+    internal class Args
     {
-        public static event Action<string> ProgressChanged;
-        public static void Report(string message)
-            => ProgressChanged?.Invoke(message);
-    }
-
-    // ====== argumentos/DTOs ======
-    internal sealed class Args
-    {
-        public string InstallDir { get; private set; }
-        public string StagingDir { get; private set; }
-        public string AppExeName { get; private set; }
-        public int ParentPid { get; private set; }
-        public string SuccessFlagPath { get; private set; }
-        public string ErrorFlagPath { get; private set; }
-        public string LogPath { get; private set; }
-        public bool CreateShortcut { get; private set; }
-        public string ShortcutName { get; private set; }
-        public string OldVersion { get; private set; }
-        public string NewVersion { get; private set; }
+        public string InstallDir;
+        public string StagingDir;
+        public string AppExeName;
+        public int ParentPid;
+        public string SuccessFlag;
+        public string ErrorFlag;
+        public string LogPath;
+        public string OldVersion;
+        public string NewVersion;
 
         public static Args Parse(string[] a)
         {
             var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            string last = null;
-            foreach (var s in a)
+            for (int i = 0; i < a.Length - 1; i += 2)
             {
-                if (s.StartsWith("--")) { last = s; d[last] = "true"; }
-                else if (last != null) { d[last] = s; last = null; }
+                if (a[i].StartsWith("--"))
+                    d[a[i]] = a[i + 1];
             }
+
+            int.TryParse(d.GetValueOrDefault("--pid"), out var pid);
 
             return new Args
             {
-                InstallDir = d.TryGet("--install"),
-                StagingDir = d.TryGet("--staging"),
-                AppExeName = d.TryGet("--exe"),
-                ParentPid = d.TryGetInt("--pid"),
-                SuccessFlagPath = d.TryGet("--success"),
-                ErrorFlagPath = d.TryGet("--error"),
-                LogPath = d.TryGet("--log"),
-                CreateShortcut = d.TryGetBool("--shortcut"),
-                ShortcutName = d.TryGet("--shortcutName", "CompillerLog.lnk"),
-                OldVersion = d.TryGet("--oldVersion"),
-                NewVersion = d.TryGet("--newVersion")
+                InstallDir = d.GetValueOrDefault("--install"),
+                StagingDir = d.GetValueOrDefault("--staging"),
+                AppExeName = d.GetValueOrDefault("--exe"),
+                ParentPid = pid,
+                SuccessFlag = d.GetValueOrDefault("--success"),
+                ErrorFlag = d.GetValueOrDefault("--error"),
+                LogPath = d.GetValueOrDefault("--log"),
+                OldVersion = d.GetValueOrDefault("--old"),
+                NewVersion = d.GetValueOrDefault("--new")
             };
         }
-
-        public override string ToString()
-        {
-            return $"Install='{InstallDir}', Staging='{StagingDir}', Exe='{AppExeName}', Pid={ParentPid}, " +
-                   $"Success='{SuccessFlagPath}', Error='{ErrorFlagPath}', Log='{LogPath}', Shortcut={CreateShortcut}, ShortcutName='{ShortcutName}', " +
-                   $"OldVersion='{OldVersion}', NewVersion='{NewVersion}'";
-        }
-    }
-
-    internal static class ArgExt
-    {
-        public static string TryGet(this Dictionary<string, string> d, string k, string def = "")
-            => d.ContainsKey(k) ? d[k] : def;
-
-        public static int TryGetInt(this Dictionary<string, string> d, string k)
-        {
-            int x; return int.TryParse(d.TryGet(k), out x) ? x : 0;
-        }
-        public static bool TryGetBool(this Dictionary<string, string> d, string k)
-        {
-            bool b; return bool.TryParse(d.TryGet(k), out b) ? b : false;
-        }
-    }
-
-    internal sealed class FileLogger
-    {
-        private readonly string _path;
-        public FileLogger(string path)
-        {
-            _path = string.IsNullOrWhiteSpace(path)
-                ? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "update.log")
-                : path;
-            try { Directory.CreateDirectory(Path.GetDirectoryName(_path)); } catch { }
-        }
-
-        public void Info(string m) => Write("INFO", m);
-        public void Warn(string m) => Write("WARN", m);
-        public void Error(string m) => Write("ERROR", m);
-
-        private void Write(string level, string msg)
-        {
-            var line = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] [{level}] {msg}";
-            try { File.AppendAllText(_path, line + Environment.NewLine); } catch { }
-        }
-    }
-
-    // ====== COM interop para atalho ======
-    [ComImport, Guid("00021401-0000-0000-C000-000000000046")]
-    internal class ShellLink { }
-
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
-     Guid("000214F9-0000-0000-C000-000000000046")]
-    internal interface IShellLinkW
-    {
-        int GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszFile, int cchMaxPath, IntPtr pfd, int fFlags);
-        int GetIDList(out IntPtr ppidl);
-        int SetIDList(IntPtr pidl);
-        int GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszName, int cchMaxName);
-        int SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-        int GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszDir, int cchMaxPath);
-        int SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-        int GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszArgs, int cchMaxPath);
-        int SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
-        int GetHotkey(out short pwHotkey);
-        int SetHotkey(short wHotkey);
-        int GetShowCmd(out int piShowCmd);
-        int SetShowCmd(int iShowCmd);
-        int GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszIconPath, int cchIconPath, out int piIcon);
-        int SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
-        int SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
-        int Resolve(IntPtr hwnd, int fFlags);
-        int SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
-    }
-
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
-     Guid("0000010B-0000-0000-C000-000000000046")]
-    internal interface IPersistFile
-    {
-        void GetClassID(out Guid pClassID);
-        [PreserveSig] int IsDirty();
-        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode);
-        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, [MarshalAs(UnmanagedType.Bool)] bool fRemember);
-        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
-        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
     }
 }
 

--- a/leituraWPF/Services/SelfUpdateService.cs
+++ b/leituraWPF/Services/SelfUpdateService.cs
@@ -1,13 +1,10 @@
-﻿// Services/SelfUpdateService.cs
+// Services/SelfUpdateService.cs
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -15,17 +12,14 @@ using Newtonsoft.Json.Linq;
 namespace leituraWPF.Services
 {
     /// <summary>
-    /// Atualizador totalmente gerenciado (sem cmd/powershell).
-    /// Baixa release do GitHub, prepara staging e chama o UpdaterHost.exe.
+    /// Serviço simples de autoatualização. Verifica o último release do GitHub,
+    /// baixa o pacote e delega a troca de arquivos ao UpdaterHost.
     /// </summary>
     public class SelfUpdateService : IUpdateService
     {
         private const string ApiUrl = "https://api.github.com/repos/loboczss/leituraWPF/releases/latest";
-        private const string AppProductName = "leituraWPF";
         private const string AppExeName = "leituraWPF.exe";
-        private const string UpdaterHostName = "UpdaterHost.exe";
-        private const int MaxRetryAttempts = 3;
-        private const int TimeoutSeconds = 60;
+        private const string UpdaterExe = "UpdaterHost.exe";
 
         private static string InstallDir => AppDomain.CurrentDomain.BaseDirectory;
 
@@ -46,441 +40,118 @@ namespace leituraWPF.Services
 
         public async Task<UpdateCheckResult> CheckForUpdatesAsync(CancellationToken ct = default)
         {
-            var r = new UpdateCheckResult();
+            var result = new UpdateCheckResult
+            {
+                LocalVersion = GetLocalVersion()
+            };
+
             try
             {
-                _logger.LogInfo("Verificando atualizações (gerenciado)...");
-
-                CleanupMarkerFiles();
-
-                var tuple = await GetVersionsWithRetryAsync(ct);
-                var local = tuple.Local;
-                var remote = tuple.Remote;
-                var ok = tuple.Ok;
-
-                r.LocalVersion = local;
-                r.RemoteVersion = remote;
-                r.RemoteFetchSuccessful = ok;
-
-                if (!ok)
-                {
-                    r.Message = "Falha ao consultar o servidor de atualizações";
-                    _logger.LogWarning(r.Message);
-                    return r;
-                }
-
-                r.UpdateAvailable = remote > local;
-                r.Success = true;
-
-                if (r.UpdateAvailable)
-                    _logger.LogInfo($"Atualização disponível: {local} → {remote}");
-                else
-                    _logger.LogInfo($"Versão atual ({local}) já é a mais recente.");
-
-                return r;
-            }
-            catch (OperationCanceledException)
-            {
-                r.Message = "Operação cancelada";
-                _logger.LogWarning(r.Message);
-                return r;
+                using var http = CreateHttpClient();
+                var json = await http.GetStringAsync(ApiUrl, ct).ConfigureAwait(false);
+                var obj = JObject.Parse(json);
+                var tag = obj["tag_name"]?.ToString();
+                result.RemoteVersion = ParseVersion(tag);
+                result.RemoteFetchSuccessful = true;
+                result.UpdateAvailable = result.RemoteVersion > result.LocalVersion;
+                result.Success = true;
             }
             catch (Exception ex)
             {
-                r.Message = ex.Message;
-                _logger.LogError("Erro ao verificar atualizações", ex);
-                return r;
+                result.Message = ex.Message;
+                _logger.LogError("Falha ao verificar atualizações", ex);
             }
+
+            return result;
         }
 
         public async Task<UpdatePerformResult> PerformUpdateAsync(CancellationToken ct = default)
         {
-            var r = new UpdatePerformResult();
-            string zipPath = null;
-            string stagingDir = null;
+            var result = new UpdatePerformResult();
 
             try
             {
-                _logger.LogInfo("Iniciando atualização (gerenciado, sem shell)...");
+                var check = await CheckForUpdatesAsync(ct).ConfigureAwait(false);
+                result.RemoteFetchSuccessful = check.RemoteFetchSuccessful;
 
-                var check = await CheckForUpdatesAsync(ct);
                 if (!check.Success || !check.UpdateAvailable)
                 {
-                    r.Success = check.Success;
-                    r.RemoteFetchSuccessful = check.RemoteFetchSuccessful;
-                    r.Message = check.Message ?? "Sem atualização disponível.";
-                    return r;
+                    result.Success = false;
+                    result.Message = check.Message ?? "Nenhuma atualização disponível.";
+                    return result;
                 }
 
-                var validation = ValidateUpdateEnvironment();
-                if (!validation.Success)
-                {
-                    r.Message = validation.Message;
-                    return r;
-                }
+                // Baixa o ZIP
+                using var http = CreateHttpClient();
+                var json = await http.GetStringAsync(ApiUrl, ct).ConfigureAwait(false);
+                var assets = (JArray)JObject.Parse(json)["assets"];
+                var url = (assets?.First as JObject)?["browser_download_url"]?.ToString();
+                if (string.IsNullOrWhiteSpace(url))
+                    throw new InvalidOperationException("Pacote de atualização não encontrado.");
 
-                _logger.LogInfo("Baixando release...");
-                zipPath = await DownloadWithValidationAsync(ct);
+                var tempZip = Path.Combine(Path.GetTempPath(), $"upd_{Guid.NewGuid():N}.zip");
+                var bytes = await http.GetByteArrayAsync(url, ct).ConfigureAwait(false);
+                File.WriteAllBytes(tempZip, bytes);
 
-                _logger.LogInfo("Preparando staging a partir do ZIP...");
-                stagingDir = PrepareStagingDirectoryFromZip(zipPath);
+                var staging = Path.Combine(Path.GetTempPath(), $"upd_{Guid.NewGuid():N}");
+                ZipFile.ExtractToDirectory(tempZip, staging);
+                File.Delete(tempZip);
 
-                var updaterPath = Path.Combine(InstallDir, UpdaterHostName);
+                // Inicia UpdaterHost
+                var updaterPath = Path.Combine(InstallDir, UpdaterExe);
                 if (!File.Exists(updaterPath))
-                    throw new InvalidOperationException($"'{UpdaterHostName}' não encontrado em {InstallDir}. Compile/copiar o projeto UpdaterHost junto ao app.");
+                    throw new FileNotFoundException("UpdaterHost não encontrado.", updaterPath);
 
-                var args = BuildUpdaterArgs(
-                    installDir: InstallDir,
-                    stagingDir: stagingDir,
-                    appExeName: AppExeName,
-                    parentPid: Process.GetCurrentProcess().Id,
-                    successFlag: UpdateSuccessMarkerPath,
-                    errorFlag: UpdateErrorMarkerPath,
-                    logPath: UpdateLogPath,
-                    oldVersion: check.LocalVersion?.ToString() ?? string.Empty,
-                    newVersion: check.RemoteVersion?.ToString() ?? string.Empty,
-                    createShortcut: true,
-                    shortcutName: "CompillerLog.lnk"
-                );
+                var args = $"--install \"{InstallDir}\" --staging \"{staging}\" --exe \"{AppExeName}\" " +
+                           $"--pid {Process.GetCurrentProcess().Id} --success \"{UpdateSuccessMarkerPath}\" " +
+                           $"--error \"{UpdateErrorMarkerPath}\" --log \"{UpdateLogPath}\" " +
+                           $"--old \"{check.LocalVersion}\" --new \"{check.RemoteVersion}\"";
 
-                _logger.LogInfo("Disparando UpdaterHost...");
-                var psi = new ProcessStartInfo
+                Process.Start(new ProcessStartInfo
                 {
                     FileName = updaterPath,
                     Arguments = args,
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     WorkingDirectory = InstallDir
-                };
+                });
 
-                var p = Process.Start(psi);
-                if (p == null)
-                    throw new InvalidOperationException("Falha ao iniciar UpdaterHost.");
-
-                // Aguarda brevemente para detectar encerramento imediato
-                await Task.Delay(1000, ct);
-                if (!p.HasExited)
-                {
-                    // Aguarda até que o UpdaterHost esteja pronto para receber
-                    // entrada (janela inicializada). Caso contrário, consideramos
-                    // que houve falha ao inicializar e abortamos a atualização.
-                    try
-                    {
-                        if (!p.WaitForInputIdle(5000))
-                        {
-                            if (p.HasExited)
-                            {
-                                var code = p.ExitCode;
-                                p.Dispose();
-                                throw new InvalidOperationException($"UpdaterHost finalizado prematuramente (código {code}).");
-                            }
-                            throw new InvalidOperationException("UpdaterHost não ficou pronto a tempo.");
-                        }
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        if (p.HasExited)
-                        {
-                            var code = p.ExitCode;
-                            p.Dispose();
-                            throw new InvalidOperationException($"UpdaterHost finalizado prematuramente (código {code}).");
-                        }
-                        throw;
-                    }
-                }
-                else
-                {
-                    var code = p.ExitCode;
-                    p.Dispose();
-
-                    // Se não houver outro processo UpdaterHost rodando, tratamos
-                    // como falha. Isso evita que o aplicativo feche sem que a
-                    // atualização seja realmente iniciada.
-                    var hostName = Path.GetFileNameWithoutExtension(UpdaterHostName);
-                    var existsOther = Process.GetProcessesByName(hostName).Any();
-                    if (!existsOther || code != 0)
-                        throw new InvalidOperationException($"UpdaterHost finalizado prematuramente (código {code}).");
-
-                    // Saiu com êxito rapidamente e existe outra instância em
-                    // execução → provavelmente relançado para elevação.
-                    _logger.LogInfo("UpdaterHost reiniciado para elevação.");
-                }
-
-                _logger.LogInfo("UpdaterHost iniciado. Feche o app para permitir a troca segura dos arquivos.");
-                r.Success = true;
-                r.RemoteFetchSuccessful = true;
-                r.Message = "Atualização iniciada.";
-                return r;
-            }
-            catch (OperationCanceledException)
-            {
-                r.Message = "Atualização cancelada.";
-                _logger.LogWarning(r.Message);
-                return r;
+                result.Success = true;
+                result.Message = "Atualização iniciada.";
             }
             catch (Exception ex)
             {
-                r.Message = ex.Message;
-                _logger.LogError("Erro durante a atualização", ex);
-                return r;
+                result.Message = ex.Message;
+                _logger.LogError("Falha ao iniciar atualização", ex);
             }
-            finally
-            {
-                try { if (zipPath != null && File.Exists(zipPath)) File.Delete(zipPath); } catch { }
-                // stagingDir é limpo pelo UpdaterHost ao final (sucesso/rollback)
-            }
+
+            return result;
         }
 
-        // ====== internos ======
-
-        private async Task<(Version Local, Version Remote, bool Ok)> GetVersionsWithRetryAsync(CancellationToken ct)
-        {
-            var local = GetLocalVersionSafely();
-            for (int i = 1; i <= MaxRetryAttempts; i++)
-            {
-                try
-                {
-                    using (var http = CreateHttp())
-                    {
-                        var json = await http.GetStringAsync(ApiUrl, ct);
-                        if (string.IsNullOrWhiteSpace(json))
-                            throw new InvalidOperationException("Resposta vazia do servidor");
-
-                        var obj = JObject.Parse(json);
-                        var tag = obj["tag_name"]?.ToString()?.Trim();
-                        if (string.IsNullOrEmpty(tag))
-                            throw new InvalidOperationException("tag_name não encontrada");
-
-                        var remote = ParseVersionFromTag(tag);
-                        if (remote == null)
-                            throw new InvalidOperationException($"Não foi possível parsear a versão: {tag}");
-
-                        _logger.LogInfo($"Local: {local} | Remota: {remote}");
-                        return (local, remote, true);
-                    }
-                }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($"Tentativa {i}/{MaxRetryAttempts} falhou: {ex.Message}");
-                    if (i == MaxRetryAttempts)
-                    {
-                        _logger.LogError("Falha final ao obter versão remota.", ex);
-                        return (local, local, false);
-                    }
-                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)), ct);
-                }
-            }
-            return (local, local, false);
-        }
-
-        private Version GetLocalVersionSafely()
+        private static Version GetLocalVersion()
         {
             try
             {
-                var v = Assembly.GetExecutingAssembly().GetName().Version;
-                if (v != null) return v;
+                return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0);
             }
-            catch { }
-
-            var candidates = new[]
+            catch
             {
-                Path.Combine(InstallDir, $"{AppProductName}.dll"),
-                Path.Combine(InstallDir, AppExeName),
-                Path.Combine(InstallDir, $"{AppProductName}.exe")
-            };
-            foreach (var c in candidates.Where(File.Exists))
-            {
-                try
-                {
-                    var v = AssemblyName.GetAssemblyName(c).Version;
-                    if (v != null) return v;
-                }
-                catch { }
+                return new Version(0, 0);
             }
-            return new Version(0, 0, 0, 0);
         }
 
-        private async Task<string> DownloadWithValidationAsync(CancellationToken ct)
+        private static HttpClient CreateHttpClient()
         {
-            for (int i = 1; i <= MaxRetryAttempts; i++)
-            {
-                try
-                {
-                    using (var http = CreateHttp())
-                    {
-                        var json = await http.GetStringAsync(ApiUrl, ct);
-                        var obj = JObject.Parse(json);
-                        var assets = (JArray)obj["assets"];
-                        if (assets == null || assets.Count == 0)
-                            throw new InvalidOperationException("Nenhum asset no release.");
-
-                        var asset = assets.FirstOrDefault(a =>
-                        {
-                            var name = a?["name"]?.ToString() ?? "";
-                            return name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
-                        });
-                        if (asset == null)
-                            throw new InvalidOperationException("Nenhum .zip encontrado.");
-
-                        var url = asset["browser_download_url"]?.ToString();
-                        var nameFile = asset["name"]?.ToString();
-                        var sizeStr = asset["size"]?.ToString();
-
-                        if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(nameFile))
-                            throw new InvalidOperationException("Asset inválido.");
-
-                        long expected = 0;
-                        long.TryParse(sizeStr, out expected);
-                        var tempZip = Path.Combine(Path.GetTempPath(), $"{AppProductName}_upd_{Guid.NewGuid():N}.zip");
-
-                        var bytes = await http.GetByteArrayAsync(url, ct);
-                        if (expected > 0 && bytes.LongLength != expected)
-                            throw new InvalidOperationException($"Tamanho inesperado. Esperado {expected}, baixado {bytes.LongLength}");
-
-                        File.WriteAllBytes(tempZip, bytes);
-
-                        using (var z = ZipFile.OpenRead(tempZip))
-                        {
-                            if (z.Entries == null || z.Entries.Count == 0)
-                            {
-                                File.Delete(tempZip);
-                                throw new InvalidOperationException("ZIP vazio/corrompido.");
-                            }
-                        }
-                        return tempZip;
-                    }
-                }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($"Download tentativa {i}/{MaxRetryAttempts} falhou: {ex.Message}");
-                    if (i == MaxRetryAttempts) throw;
-                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)), ct);
-                }
-            }
-            return null;
-        }
-
-        private (bool Success, string Message) ValidateUpdateEnvironment()
-        {
-            try
-            {
-                if (!Directory.Exists(InstallDir))
-                    return (false, "Diretório de instalação não encontrado.");
-
-                var test = Path.Combine(InstallDir, $"wtest_{Guid.NewGuid():N}.tmp");
-                try { File.WriteAllText(test, "ok"); File.Delete(test); }
-                catch { /* sem permissão agora; UpdaterHost tentará elevar */ }
-
-                var drive = new DriveInfo(Path.GetPathRoot(InstallDir) ?? "C:");
-                if (drive.AvailableFreeSpace < 100 * 1024 * 1024)
-                    return (false, "Espaço em disco insuficiente (<100MB).");
-
-                return (true, "ok");
-            }
-            catch (Exception ex) { return (false, $"Falha na validação: {ex.Message}"); }
-        }
-
-        private string PrepareStagingDirectoryFromZip(string zipPath)
-        {
-            var stagingRoot = Path.Combine(Path.GetTempPath(), $"{AppProductName}_staging_{Guid.NewGuid():N}");
-            Directory.CreateDirectory(stagingRoot);
-            ZipFile.ExtractToDirectory(zipPath, stagingRoot);
-
-            var sub = Directory.GetDirectories(stagingRoot);
-            var filesAtRoot = Directory.GetFiles(stagingRoot);
-            if (sub.Length == 1 && filesAtRoot.Length == 0)
-                return sub[0];
-
-            return stagingRoot;
-        }
-
-        private string BuildUpdaterArgs(string installDir, string stagingDir, string appExeName,
-            int parentPid, string successFlag, string errorFlag, string logPath,
-            string oldVersion, string newVersion,
-            bool createShortcut, string shortcutName)
-        {
-            var sb = new StringBuilder();
-            void A(string k, string v) { sb.Append(' ').Append(k).Append(' ').Append(EscapeArg(v)); }
-            void B(string k, int v) { sb.Append(' ').Append(k).Append(' ').Append(v); }
-            void C(string k, bool v) { sb.Append(' ').Append(k).Append(' ').Append(v ? "true" : "false"); }
-
-            A("--install", installDir);
-            A("--staging", stagingDir);
-            A("--exe", appExeName);
-            B("--pid", parentPid);
-            A("--success", successFlag);
-            A("--error", errorFlag);
-            A("--log", logPath);
-            A("--oldVersion", oldVersion);
-            A("--newVersion", newVersion);
-            C("--shortcut", createShortcut);
-            A("--shortcutName", shortcutName);
-
-            return sb.ToString();
-        }
-
-        private static string EscapeArg(string s)
-        {
-            if (string.IsNullOrEmpty(s)) return "\"\"";
-            bool needQuotes = s.IndexOf(' ') >= 0 || s.IndexOf('\t') >= 0 || s.IndexOf('\"') >= 0 || s.EndsWith("\\");
-            if (!needQuotes) return s;
-
-            var sb = new StringBuilder();
-            sb.Append('"');
-            int backslashes = 0;
-            foreach (char c in s)
-            {
-                if (c == '\\')
-                {
-                    backslashes++;
-                }
-                else if (c == '"')
-                {
-                    sb.Append(new string('\\', backslashes * 2 + 1));
-                    sb.Append('"');
-                    backslashes = 0;
-                }
-                else
-                {
-                    sb.Append(new string('\\', backslashes));
-                    backslashes = 0;
-                    sb.Append(c);
-                }
-            }
-            sb.Append(new string('\\', backslashes * 2));
-            sb.Append('"');
-            return sb.ToString();
-        }
-
-        private HttpClient CreateHttp()
-        {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var h = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
-            var http = new HttpClient(h) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
-            http.DefaultRequestHeaders.Add("User-Agent", $"{AppProductName}/1.0 (Windows NT 10.0; Win64; x64)");
-            http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
-            http.DefaultRequestHeaders.AcceptEncoding.ParseAdd("gzip");
-            http.DefaultRequestHeaders.AcceptEncoding.ParseAdd("deflate");
+            var http = new HttpClient();
+            http.DefaultRequestHeaders.UserAgent.ParseAdd("leituraWPF");
             return http;
         }
 
-        private void CleanupMarkerFiles()
+        private static Version ParseVersion(string tag)
         {
-            try
-            {
-                var files = new[] { UpdateSuccessMarkerPath, UpdateErrorMarkerPath };
-                foreach (var f in files) if (File.Exists(f)) File.Delete(f);
-            }
-            catch (Exception ex) { _logger.LogWarning($"Falha ao limpar flags: {ex.Message}"); }
-        }
-
-        private static Version ParseVersionFromTag(string tagName)
-        {
-            if (string.IsNullOrWhiteSpace(tagName)) return new Version(0, 0, 0, 0);
-            var s = new string(tagName.Trim().TrimStart('v', 'V')
-                          .TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
-            Version v; return Version.TryParse(s, out v) ? v : new Version(0, 0, 0, 0);
+            if (string.IsNullOrWhiteSpace(tag)) return new Version(0, 0);
+            tag = tag.Trim().TrimStart('v', 'V');
+            return Version.TryParse(tag, out var v) ? v : new Version(0, 0);
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Simplify self-update service to check GitHub releases and trigger updater host
- Rewrite updater host to copy new files and relaunch application

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ebb4d6a88333bd89f8d7e676d701