### PR TITLE
Ensure version file is generated on startup

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,6 +81,7 @@ namespace leituraWPF
         {
             try { StartupService.ConfigureStartup(); } catch { }
 
+            EnsureVersionFile();
             LoadConfiguration();
 
             var tokenService = new TokenService(Config);
@@ -291,6 +293,26 @@ namespace leituraWPF
                     {
                     }
                 });
+            }
+            catch
+            {
+            }
+        }
+
+        private static void EnsureVersionFile()
+        {
+            try
+            {
+                var asmVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                if (asmVersion == null)
+                    return;
+
+                var current = $"v{asmVersion}";
+                var path = Path.Combine(AppContext.BaseDirectory, "version.txt");
+
+                var existing = File.Exists(path) ? File.ReadAllText(path).Trim() : string.Empty;
+                if (existing != current)
+                    File.WriteAllText(path, current);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- create helper to check and write version.txt with current assembly version
- invoke version file check during application startup

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0e5512d083339cd173dccac577bd