### PR TITLE
Prevent log errors during shutdown

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -679,7 +679,19 @@ namespace leituraWPF
                 txtLog.ScrollToEnd();
                 if (GridLog.Items.Count > 0) GridLog.ScrollIntoView(GridLog.Items[GridLog.Items.Count - 1]);
             }
-            if (Dispatcher.CheckAccess()) Append(); else Dispatcher.Invoke(Append);
+
+            // Evita exceções quando a aplicação está sendo finalizada
+            if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+                return;
+
+            try
+            {
+                if (Dispatcher.CheckAccess()) Append(); else Dispatcher.Invoke(Append);
+            }
+            catch (TaskCanceledException)
+            {
+                // O Dispatcher foi finalizado; ignorar logs pendentes
+            }
         }
 
         public void Report(double value)


### PR DESCRIPTION
## Summary
- Avoid logging to UI when dispatcher is shutting down
- Ignore TaskCanceledException in log updates during app exit

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb186034008333bbca48a050336d2d