### PR TITLE
Reduce auto-update timer to 30s with visible countdown

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -294,7 +294,7 @@ namespace leituraWPF
                 var prompt = new UpdatePromptWindow(
                     check.LocalVersion ?? new Version(0, 0),
                     check.RemoteVersion ?? new Version(0, 0),
-                    timeoutSeconds: 60)
+                    timeoutSeconds: 30)
                 {
                     Owner = this
                 };

--- a/leituraWPF/Services/UpdatePoller.cs
+++ b/leituraWPF/Services/UpdatePoller.cs
@@ -126,7 +126,7 @@ namespace leituraWPF.Services
                     var win = new UpdatePromptWindow(
                         check.LocalVersion ?? new Version(0, 0),
                         check.RemoteVersion ?? new Version(0, 0),
-                        timeoutSeconds: 60);
+                        timeoutSeconds: 30);
 
                     if (owner != null) win.Owner = owner;
 

--- a/leituraWPF/Views/UpdatePromptWindow.xaml
+++ b/leituraWPF/Views/UpdatePromptWindow.xaml
@@ -230,13 +230,17 @@
                            Margin="0,0,0,12"/>
 
                 <!-- Status de Auto-atualização -->
-                <Border Background="#fff3cd" BorderBrush="#ffeaa7" BorderThickness="1" 
+                <Border Background="#fff3cd" BorderBrush="#ffeaa7" BorderThickness="1"
                         CornerRadius="8" Padding="12,8" Margin="0,0,0,8">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="⏱️" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                        <TextBlock x:Name="TxtAuto" Text="A atualização será aplicada automaticamente"
-                                   FontSize="13" Foreground="#856404" VerticalAlignment="Center"
-                                   FontStyle="Italic"/>
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="⏱️" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="TxtAuto" Text="A atualização será aplicada automaticamente"
+                                       FontSize="13" Foreground="#856404" VerticalAlignment="Center"
+                                       FontStyle="Italic"/>
+                        </StackPanel>
+                        <ProgressBar x:Name="AutoProgressBar" Height="4" Margin="24,4,0,0" Minimum="0" Value="0"
+                                     Background="#ffeaa7" Foreground="#856404"/>
                     </StackPanel>
                 </Border>
             </StackPanel>

--- a/leituraWPF/Views/UpdatePromptWindow.xaml.cs
+++ b/leituraWPF/Views/UpdatePromptWindow.xaml.cs
@@ -7,9 +7,10 @@ namespace leituraWPF
     public partial class UpdatePromptWindow : Window
     {
         private readonly DispatcherTimer _timer;
+        private readonly int _totalSeconds;
         private int _seconds;
 
-        public UpdatePromptWindow(Version local, Version remote, int timeoutSeconds = 60)
+        public UpdatePromptWindow(Version local, Version remote, int timeoutSeconds = 30)
         {
             InitializeComponent();
 
@@ -17,6 +18,8 @@ namespace leituraWPF
             LblRemoteVer.Text = remote?.ToString() ?? "-";
 
             _seconds = Math.Max(5, timeoutSeconds); // pequena proteção
+            _totalSeconds = _seconds;
+            AutoProgressBar.Maximum = _totalSeconds;
             UpdateCountdownText();
 
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
@@ -39,6 +42,7 @@ namespace leituraWPF
         private void UpdateCountdownText()
         {
             TxtAuto.Text = $"A atualização iniciará automaticamente em {_seconds}s...";
+            AutoProgressBar.Value = _totalSeconds - _seconds;
         }
 
         private void BtnNow_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- shorten auto-update countdown from 60s to 30s
- add progress bar to update prompt to visually show countdown

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Error opening icon file ico-app.ico)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2c019534833388b6ffdc62e5fe16