### PR TITLE
Ensure backup upload runs during login and main screens

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -78,6 +78,8 @@ namespace leituraWPF
             _backup = backupService ?? new BackupUploaderService(Program.Config, _tokenService);
             _listaService = new ListaService(Program.Config, _tokenService);
 
+            // Garante que o serviço de upload esteja sempre ativo
+            _backup.Start();
 
             _renamer.FileReadyForBackup += async p => await _backup.EnqueueAsync(p);
             _installRenamer.FileReadyForBackup += async p => await _backup.EnqueueAsync(p);
@@ -138,12 +140,10 @@ namespace leituraWPF
                 });
             };
 
-
             if (backupService == null)
-
             {
+                // quando criado internamente, carregar pendentes em segundo plano
                 _ = _backup.LoadPendingFromBaseDirsAsync();
-                _backup.Start();
             }
 
             // inicia sincronização automática a cada 10 minutos (cancelável)

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -103,12 +103,17 @@ namespace leituraWPF
                 backup = new BackupUploaderService(Config, tokenService);
                 BackupInstance = backup;
 
+                // Inicia imediatamente o serviço de upload para que
+                // funcione desde a tela de login
+                backup.Start();
+
+                // Carrega os arquivos pendentes em segundo plano sem
+                // bloquear a inicialização da aplicação
                 _ = Task.Run(async () =>
                 {
                     try
                     {
                         await backup.LoadPendingFromBaseDirsAsync();
-                        backup.Start();
                     }
                     catch
                     {

--- a/leituraWPF/Views/LoginWindow.xaml.cs
+++ b/leituraWPF/Views/LoginWindow.xaml.cs
@@ -98,6 +98,9 @@ namespace leituraWPF
 
             try
             {
+                // garante que o serviço de backup esteja ativo também na tela de login
+                _backup.Start();
+
                 BtnLogin.IsEnabled = false;
                 StatusMessage = "Carregando...";
 


### PR DESCRIPTION
## Summary
- Start backup uploader service immediately on app launch
- Guarantee backup service runs on login and main windows
- Load pending backup files in background without delaying UI

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb33d79c1883338956d04d3b3235fd