### PR TITLE
Add retry for failed backup uploads

### DIFF
--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -431,11 +431,20 @@
                             <!-- Lista Erros -->
                             <StackPanel Grid.Column="2" Margin="8,0,0,0">
                                 <Border Background="{StaticResource RedLight}" CornerRadius="8" Padding="12,8" Margin="0,0,0,12">
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="❌" FontSize="16" Margin="0,0,8,0"/>
-                                        <TextBlock Text="Arquivos com Erro" FontWeight="SemiBold" FontSize="14" 
-                                                   Foreground="{StaticResource TextDark}"/>
-                                    </StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Horizontal" Grid.Column="0">
+                                            <TextBlock Text="❌" FontSize="16" Margin="0,0,8,0"/>
+                                            <TextBlock Text="Arquivos com Erro" FontWeight="SemiBold" FontSize="14"
+                                                       Foreground="{StaticResource TextDark}"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="1" Content="↻ Reenviar" Style="{StaticResource ModernButton}"
+                                                Background="{StaticResource ErrorRed}" Margin="12,0,0,0"
+                                                Click="RetryErrors_Click"/>
+                                    </Grid>
                                 </Border>
                                 <ScrollViewer Height="300" VerticalScrollBarVisibility="Auto">
                                     <ItemsControl x:Name="ErrorList">

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -281,6 +281,26 @@ namespace leituraWPF
                 Debug.WriteLine($"Erro ao atualizar contadores: {ex.Message}");
             }
         }
+
+        private async void RetryErrors_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await _backup.RetryErrorsAsync();
+                await RefreshCollectionsAsync();
+
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    _errors.Clear();
+                }, DispatcherPriority.Background);
+
+                await _backup.ForceRunOnceAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erro ao reenviar arquivos: {ex.Message}");
+            }
+        }
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
## Summary
- add button to retry sending failed backup files
- allow service to requeue error files for upload

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3f3d4674833393e8978a9e49b7dd