### PR TITLE
Add resend option for error history in backup status window

### DIFF
--- a/leituraWPF/Views/BackupStatusWindow.xaml
+++ b/leituraWPF/Views/BackupStatusWindow.xaml
@@ -563,18 +563,25 @@
                                         <DataGrid x:Name="HistoryErrorList" ItemsSource="{Binding HistoryErrors}"
                                                   AutoGenerateColumns="False" IsReadOnly="True" MinHeight="300">
                                             <DataGrid.Columns>
-                                                <DataGridTextColumn Header="📅 Data" 
-                                                    Binding="{Binding CompletedAt, StringFormat={}{0:dd/MM/yyyy HH:mm}}" 
+                                                <DataGridTextColumn Header="📅 Data"
+                                                    Binding="{Binding CompletedAt, StringFormat={}{0:dd/MM/yyyy HH:mm}}"
                                                     Width="140"/>
                                                 <DataGridTextColumn Header="📄 Arquivo" Binding="{Binding FileName}" Width="*"/>
-                                                <DataGridTemplateColumn Header="🔧 Ação" Width="80">
+                                                <DataGridTemplateColumn Header="🔧 Ação" Width="120">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>
-                                                            <Button Content="📂" Tag="{Binding FilePath}" 
-                                                                    Click="OpenFileLocation_Click" 
-                                                                    Style="{StaticResource ModernButton}"
-                                                                    Width="28" Height="28" Padding="0"
-                                                                    ToolTip="Abrir localização"/>
+                                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                                <Button Content="↻" Tag="{Binding FilePath}"
+                                                                        Click="RetryHistory_Click"
+                                                                        Style="{StaticResource ModernButton}"
+                                                                        Width="28" Height="28" Padding="0"
+                                                                        ToolTip="Reenviar" Margin="0,0,8,0"/>
+                                                                <Button Content="📂" Tag="{Binding FilePath}"
+                                                                        Click="OpenFileLocation_Click"
+                                                                        Style="{StaticResource ModernButton}"
+                                                                        Width="28" Height="28" Padding="0"
+                                                                        ToolTip="Abrir localização"/>
+                                                            </StackPanel>
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>

--- a/leituraWPF/Views/BackupStatusWindow.xaml.cs
+++ b/leituraWPF/Views/BackupStatusWindow.xaml.cs
@@ -301,6 +301,24 @@ namespace leituraWPF
                 Debug.WriteLine($"Erro ao reenviar arquivos: {ex.Message}");
             }
         }
+
+        private async void RetryHistory_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.Button btn && btn.Tag is string path)
+            {
+                try
+                {
+                    await _backup.RetryErrorAsync(path);
+                    await RefreshCollectionsAsync();
+                    await LoadHistoryAsync();
+                    await _backup.ForceRunOnceAsync();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erro ao reenviar arquivo do histórico: {ex.Message}");
+                }
+            }
+        }
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
## Summary
- allow resending individual historical errors
- expose service helper to requeue a single errored file

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4268bca483339902af5e6f412f40