### PR TITLE
Prevent update timer from restarting countdown

### DIFF
--- a/leituraWPF/Services/UpdatePoller.cs
+++ b/leituraWPF/Services/UpdatePoller.cs
@@ -137,6 +137,10 @@ namespace leituraWPF.Services
                 if (!wantsUpdate) return;
 
                 // 4) Executa a atualização (abre o AtualizaAPP.exe na subpasta "AtualizaAPP")
+                // Impede novas execuções do timer enquanto a atualização ocorre
+                _disposed = true;
+                try { _timer.Dispose(); } catch { /* ignore */ }
+
                 var update = await _service.PerformUpdateAsync().ConfigureAwait(false);
                 if (!update.Success)
                 {


### PR DESCRIPTION
## Summary
- Stop `UpdatePoller` timer once update is confirmed to avoid multiple countdown cycles

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d10d1e48333a0903f07c7f9f082