### PR TITLE
Check for updates every second and avoid duplicate prompts

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -229,9 +229,9 @@ namespace leituraWPF
             return new UpdatePoller(
                 service: svc,
                 ownerResolver: () => GetCurrentVisibleWindow(login),
-                baseInterval: TimeSpan.FromMinutes(15),
-                maxInterval: TimeSpan.FromHours(2),
-                initialDelay: TimeSpan.FromSeconds(30)
+                baseInterval: TimeSpan.FromSeconds(1),
+                maxInterval: TimeSpan.FromSeconds(1),
+                initialDelay: TimeSpan.Zero
             );
         }
 

--- a/leituraWPF/Services/UpdatePoller.cs
+++ b/leituraWPF/Services/UpdatePoller.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using WpfApp = System.Windows.Application;
 using WpfWindow = System.Windows.Window;
 using ThreadingTimer = System.Threading.Timer;
+using leituraWPF;
 
 namespace leituraWPF.Services
 {
@@ -115,6 +116,9 @@ namespace leituraWPF.Services
 
                 bool wantsUpdate = await dispatcher.InvokeAsync(() =>
                 {
+                    if (IsPromptOpen())
+                        return false;
+
                     WpfWindow owner = null;
                     try
                     {
@@ -164,6 +168,21 @@ namespace leituraWPF.Services
                 if (!_disposed)
                     ScheduleNext(offlineFailure);
             }
+        }
+
+        private static bool IsPromptOpen()
+        {
+            try
+            {
+                if (WpfApp.Current == null) return false;
+                foreach (WpfWindow w in WpfApp.Current.Windows)
+                {
+                    if (w is UpdatePromptWindow upw && upw.IsVisible)
+                        return true;
+                }
+            }
+            catch { }
+            return false;
         }
 
         private void ScheduleNext(bool wasFailure)


### PR DESCRIPTION
## Summary
- Poll for app updates every second
- Skip opening a new update prompt if one is already visible

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f84ad7483338132637b14aa5658