### PR TITLE
Check updates every second and prevent duplicate prompts

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -302,16 +302,13 @@ namespace leituraWPF
                 var check = await updater.CheckForUpdatesAsync();
                 if (!check.Success || !check.UpdateAvailable) return;
 
-                var prompt = new UpdatePromptWindow(
+                var wantsUpdate = Program.TryShowUpdatePrompt(
                     check.LocalVersion ?? new Version(0, 0),
                     check.RemoteVersion ?? new Version(0, 0),
-                    timeoutSeconds: 30)
-                {
-                    Owner = this
-                };
-                var result = prompt.ShowDialog();
+                    this,
+                    timeoutSeconds: 30);
 
-                if (result != false)
+                if (wantsUpdate)
                 {
                     var update = await updater.PerformUpdateAsync();
                     if (!update.Success)

--- a/leituraWPF/Services/UpdatePoller.cs
+++ b/leituraWPF/Services/UpdatePoller.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using leituraWPF;
 // Evitar colisões com WPF:
 // (não use "using System.Windows;" direto aqui)
 using WpfApp = System.Windows.Application;
@@ -123,15 +124,11 @@ namespace leituraWPF.Services
                     }
                     catch { /* ignore */ }
 
-                    var win = new UpdatePromptWindow(
+                    return Program.TryShowUpdatePrompt(
                         check.LocalVersion ?? new Version(0, 0),
                         check.RemoteVersion ?? new Version(0, 0),
+                        owner,
                         timeoutSeconds: 30);
-
-                    if (owner != null) win.Owner = owner;
-
-                    bool? dlg = win.ShowDialog();
-                    return dlg == true;
                 });
 
                 if (!wantsUpdate) return;


### PR DESCRIPTION
## Summary
- Poll for updates every second and track when an update prompt is already open
- Show version notification once and reuse in login or main windows

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f84ad7483338132637b14aa5658