### PR TITLE
Log NUMOS details in SharePoint sync

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -576,7 +576,7 @@ namespace leituraWPF
                         var arquivos = Directory.GetFiles(destino).Select(Path.GetFileName);
                         var versao = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
                         var usuario = _funcionario?.Nome ?? Environment.UserName;
-                        await _processadosService.AddAsync(destino, usuario, arquivos, versao);
+                        await _processadosService.AddAsync(record.NumOS, destino, usuario, arquivos, versao);
                         await _processadosService.TrySyncAsync();
                     }
                 }


### PR DESCRIPTION
## Summary
- use NUMOS as the SharePoint item title and add Pasta column
- ensure required columns exist and remove probe item after verification
- record NUMOS when logging processed folders

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c04947553c8333bd7ae5b1fa1d035b