### PR TITLE
Handle SharePoint sync probe failures

### DIFF
--- a/leituraWPF/Services/ProcessadosService.cs
+++ b/leituraWPF/Services/ProcessadosService.cs
@@ -100,11 +100,19 @@ namespace leituraWPF.Services
                 }
                 _listId ??= listId;
 
-                // Teste rápido: cria item mínimo (só Title). Se falhar -> permissão/rota/tokens.
-                await ProbeCreateMinimalItemAsync(siteSpec, listId).ConfigureAwait(false);
-
-                // Garante colunas
+                // Garante que a lista possua todas as colunas necessárias
                 await EnsureColumnsAsync(siteSpec, listId).ConfigureAwait(false);
+
+                // Teste rápido: cria item mínimo (só Title). Se falhar, registra e tenta prosseguir
+                try
+                {
+                    await ProbeCreateMinimalItemAsync(siteSpec, listId).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    await LogAsync("PROBE falhou: " + ex.Message + ". Prosseguindo com sync.")
+                        .ConfigureAwait(false);
+                }
 
                 string itemsUrl = $"https://graph.microsoft.com/v1.0/{siteSpec}/lists/{listId}/items";
                 int ok = 0, fail = 0;


### PR DESCRIPTION
## Summary
- Ensure SharePoint log list columns exist before probing
- Log and continue sync if probe item creation fails

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b49b06e4833394f59575ebada8f8