### PR TITLE
Capture Windows username for SharePoint PC column

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -576,7 +576,8 @@ namespace leituraWPF
                         var arquivos = Directory.GetFiles(destino).Select(Path.GetFileName);
                         var versao = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
                         var usuario = _funcionario?.Nome ?? Environment.UserName;
-                        await _processadosService.AddAsync(record.NumOS, destino, usuario, arquivos, versao);
+                        var pc = Environment.UserName;
+                        await _processadosService.AddAsync(record.NumOS, destino, usuario, pc, arquivos, versao);
                         await _processadosService.TrySyncAsync();
                     }
                 }


### PR DESCRIPTION
## Summary
- Store Windows login in new `Pc` field for process logs
- Map and sync `PC` column to SharePoint alongside existing metadata
- Pass Windows username from main window when logging processed items

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found; WPF build not supported on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c82fb2f4833391e2672d0b163cca