### PR TITLE
Use Windows display name for SharePoint PC column

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.DirectoryServices.AccountManagement;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -577,6 +578,14 @@ namespace leituraWPF
                         var versao = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
                         var usuario = _funcionario?.Nome ?? Environment.UserName;
                         var pc = Environment.UserName;
+                        try
+                        {
+                            pc = UserPrincipal.Current?.DisplayName ?? pc;
+                        }
+                        catch
+                        {
+                            // Ignora falhas e mantém Environment.UserName
+                        }
                         await _processadosService.AddAsync(record.NumOS, destino, usuario, pc, arquivos, versao);
                         await _processadosService.TrySyncAsync();
                     }


### PR DESCRIPTION
## Summary
- record PC column using Windows login display name rather than profile folder name

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ca69bfe88333860acae2a624f360