### PR TITLE
Ler funcionarios de lista do SharePoint com cache offline

### DIFF
--- a/leituraWPF/Models/Funcionario.cs
+++ b/leituraWPF/Models/Funcionario.cs
@@ -1,7 +1,7 @@
 namespace leituraWPF.Models
 {
     /// <summary>
-    /// Representa um funcionário conforme armazenado no arquivo funcionarios.csv.
+    /// Representa um funcionário obtido da lista do SharePoint ou do cache local.
     /// </summary>
     public record Funcionario(
         string Matricula,


### PR DESCRIPTION
## Summary
- Ler dados de funcionários da lista do SharePoint e salvar em `funcionarios.json`
- Carregar funcionários do cache JSON e incluir usuário administrador 258790
- Ajustar tela de login para usar o novo cache e permitir acesso administrativo sem arquivo

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cfa30bc08333ad2d9180b5e1b5c7