### PR TITLE
Ajusta frequência de atualização para 5 minutos

### DIFF
--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -230,8 +230,8 @@ namespace leituraWPF
             return new UpdatePoller(
                 service: svc,
                 ownerResolver: () => GetCurrentVisibleWindow(login),
-                baseInterval: TimeSpan.FromSeconds(1),
-                maxInterval: TimeSpan.FromSeconds(1),
+                baseInterval: TimeSpan.FromMinutes(5),
+                maxInterval: TimeSpan.FromMinutes(5),
                 initialDelay: TimeSpan.Zero
             );
         }


### PR DESCRIPTION
## Summary
- Altera `UpdatePoller` para usar intervalo base e máximo de 5 minutos

## Testing
- `dotnet build` (falhou: Microsoft.NET.Sdk.WindowsDesktop.targets not found)

------
https://chatgpt.com/codex/tasks/task_e_68c33c868344833382571453d9151c0d