### PR TITLE
Fix SharePoint login list link

### DIFF
--- a/leituraWPF/Services/FuncionarioService.cs
+++ b/leituraWPF/Services/FuncionarioService.cs
@@ -55,7 +55,7 @@ namespace leituraWPF.Services
             _http.DefaultRequestHeaders.Accept.Clear();
             _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            var url = $"https://graph.microsoft.com/v1.0/sites/{_cfg.SiteId}/lists/{_cfg.ListId}/items?expand=fields(select=Matricula,Nome)&$top=5000";
+            var url = $"https://graph.microsoft.com/v1.0/sites/{_cfg.SiteId}/lists/{_cfg.FuncionarioListId}/items?expand=fields(select=Matricula,Nome)&$top=5000";
             using var resp = await _http.GetAsync(url, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode) return null;
 

--- a/leituraWPF/Utils/AppConfig.cs
+++ b/leituraWPF/Utils/AppConfig.cs
@@ -14,6 +14,7 @@ namespace leituraWPF.Utils
         // ==== SharePoint origem (manutenção/instalação) ====
         public string SiteId { get; set; } = "";
         public string ListId { get; set; } = "";
+        public string FuncionarioListId { get; set; } = "";
         public string ProcessLogListName { get; set; } = "ListCompillerLog";
 
         public List<string>? WantedPrefixes { get; set; }

--- a/leituraWPF/appsettings.json
+++ b/leituraWPF/appsettings.json
@@ -12,6 +12,7 @@
 
   "SiteId": "03b55b3a-5e43-430f-90db-687ed2c5b32f",
   "ListId": "eeee4abc-d931-4f12-b88b-747d024baf7f",
+  "FuncionarioListId": "69ecf1ce-386c-4e49-8607-7391aa3f734b",
   "ProcessLogListName": "ListCompillerLog",
 
   "WantedPrefixes": [


### PR DESCRIPTION
## Summary
- add configuration field for employee list and use it when downloading login data
- point employee list to `colaboradores_automate` SharePoint list

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c33f5149e08333b14fbf30ba5268a0