### PR TITLE
Stop counting downloaded files

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -242,10 +242,6 @@ namespace leituraWPF
                         extraQueries: new[] { "Instalacao_AC", "Instalacao_MT" }
                     );
 
-                    var stats = SyncStatsService.Load();
-                    stats.Downloaded += downloaded.Count;
-                    SyncStatsService.Save(stats);
-
                     SetStatus($"Download finalizado. {downloaded.Count} arquivo(s).");
                     SetStatus("Atualizando cache local (manutenção)...");
                     await EnsureLocalCacheAsync(forceReload: true);

--- a/leituraWPF/Views/LoginWindow.xaml.cs
+++ b/leituraWPF/Views/LoginWindow.xaml.cs
@@ -204,7 +204,7 @@ namespace leituraWPF
 
                 if (!ct.IsCancellationRequested)
                 {
-                    StatusMessage = $"Enviados: {stats.Uploaded} | Baixados: {stats.Downloaded}";
+                    StatusMessage = $"Enviados: {stats.Uploaded}";
 
                     var statusBorder = FindName("StatusBorder") as FrameworkElement;
                     if (statusBorder != null)
@@ -334,7 +334,7 @@ namespace leituraWPF
                     try
                     {
                         var stats = SyncStatsService.Load();
-                        StatusMessage = $"Enviados: {stats.Uploaded} | Baixados: {stats.Downloaded}";
+                        StatusMessage = $"Enviados: {stats.Uploaded}";
                     }
                     catch
                     {


### PR DESCRIPTION
## Summary
- Stop updating download statistics during sync
- Show only uploaded file count on login status

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3527045ac83338e17ce35858ab069