### PR TITLE
Ensure tray exit fully terminates application

### DIFF
--- a/leituraWPF/MainWindow.xaml.cs
+++ b/leituraWPF/MainWindow.xaml.cs
@@ -187,9 +187,8 @@ namespace leituraWPF
                 _cts.Cancel();
                 _autoSyncTimer.Dispose();
                 _processadosTimer.Dispose();
-                // Se seu BackupUploaderService tiver Stop(), chame aqui:
-                // _backup.Stop();
-                // Removido cast para IDisposable (classe não implementa IDisposable)
+                // garante que quaisquer uploads em andamento sejam interrompidos
+                _backup.Stop();
             }
             catch { /* noop */ }
             base.OnClosed(e);

--- a/leituraWPF/Program.cs
+++ b/leituraWPF/Program.cs
@@ -401,9 +401,18 @@ namespace leituraWPF
                         try { proc.Kill(); } catch { }
                     }
                 }
-                current.Kill();
             }
             catch { }
+
+            try
+            {
+                // garante encerramento mesmo se threads em segundo plano permanecerem ativas
+                Environment.Exit(0);
+            }
+            catch
+            {
+                try { Process.GetCurrentProcess().Kill(); } catch { }
+            }
         }
 
         private static void EnsureVersionFile()


### PR DESCRIPTION
## Summary
- Stop backup uploader service when main window closes
- Forcefully end process after disposing services to avoid lingering instances

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ce738f94833391930dddfa01f3d9